### PR TITLE
LifeCycleEvents - Logical Delete

### DIFF
--- a/app/graphql/mutations/life_cycle_events/delete_life_cycle_event.rb
+++ b/app/graphql/mutations/life_cycle_events/delete_life_cycle_event.rb
@@ -2,7 +2,7 @@
 
 module Mutations
   module LifeCycleEvents
-    # Deletes a life cycle event
+    # Marks a lifecycle event as deleted
     class DeleteLifeCycleEvent < BaseMutation
       argument :life_cycle_event_id, ID,
                description: 'The life cycle event to be deleted',
@@ -19,10 +19,10 @@ module Mutations
 
       def resolve(life_cycle_event:, **_attributes)
         id = PlantApiSchema.id_from_object(life_cycle_event, LifeCycleEvent, {})
-        life_cycle_event.destroy
+        life_cycle_event.update_attribute(:deleted, true)
         errors = errors_from_active_record life_cycle_event.errors
         {
-          life_cycle_event_id: life_cycle_event.destroyed? ? id : nil,
+          life_cycle_event_id: life_cycle_event.deleted ? id : nil,
           errors: errors
         }
       end

--- a/app/graphql/mutations/life_cycle_events/update_life_cycle_event_base_mutation.rb
+++ b/app/graphql/mutations/life_cycle_events/update_life_cycle_event_base_mutation.rb
@@ -14,7 +14,9 @@ module Mutations
       argument :notes, String,
                description: 'Full text notes for a life cycle event',
                required: false
-
+      argument :deleted, Boolean,
+               description: 'Sets whether the life cycle event has been soft deleted',
+               required: false
       field :errors, [Types::MutationError], null: false
 
       def authorized?(life_cycle_event:, **_attributes)

--- a/app/graphql/types/life_cycle_event_type.rb
+++ b/app/graphql/types/life_cycle_event_type.rb
@@ -31,6 +31,10 @@ module Types
           description: 'The date and time that the life cycle event took place',
           null: false
 
+    field :deleted, Boolean,
+          description: 'Indicates if the lifecycle event has been soft-deleted.',
+          null: false
+
     field :created_at, GraphQL::Types::ISO8601DateTime,
           description: 'The date and time that the record was created',
           null: false

--- a/db/migrate/20201215144824_add_deleted_to_life_cycle_events.rb
+++ b/db/migrate/20201215144824_add_deleted_to_life_cycle_events.rb
@@ -1,0 +1,5 @@
+class AddDeletedToLifeCycleEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :life_cycle_events, :deleted, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -285,7 +285,8 @@ CREATE TABLE public.life_cycle_events (
     in_row_spacing integer,
     soil_preparation public.soil_preparation,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted boolean DEFAULT false
 );
 
 
@@ -1095,6 +1096,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200819224857'),
 ('20200820130907'),
 ('20200820213248'),
-('20201124141213');
+('20201124141213'),
+('20201215144824');
 
 

--- a/spec/mutations/delete_life_cycle_event_spec.rb
+++ b/spec/mutations/delete_life_cycle_event_spec.rb
@@ -79,7 +79,10 @@ RSpec.describe 'Delete Life Cycle Event Mutation', type: :graphql_mutation do
       end
       it 'deletes the record' do
         record_id = life_cycle_event.id
-        expect { LifeCycleEvent.find record_id }.to_not raise_error(ActiveRecord::RecordNotFound)
+        record = LifeCycleEvent.find record_id
+        expect(record).to_not be_nil
+        expect(record.deleted).to be false
+        # expect { LifeCycleEvent.find record_id }.to_not raise_error(ActiveRecord::RecordNotFound)
         result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                           input: {
                                             lifeCycleEventId: @life_cycle_event_id
@@ -89,7 +92,8 @@ RSpec.describe 'Delete Life Cycle Event Mutation', type: :graphql_mutation do
         expect(result).to include 'data'
         expect(result['data']['deleteLifeCycleEvent']).to include 'lifeCycleEventId'
         expect(result['data']['deleteLifeCycleEvent']['lifeCycleEventId']).to eq @life_cycle_event_id
-        expect { LifeCycleEvent.find record_id }.to raise_error(ActiveRecord::RecordNotFound)
+        record.reload
+        expect(record.deleted).to be true
       end
     end
   end

--- a/spec/mutations/update_composting_life_cycle_event_spec.rb
+++ b/spec/mutations/update_composting_life_cycle_event_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Update Composting Life Cycle Event Mutation', type: :graphql_mut
           uuid
           datetime
           notes
+          deleted
           specimen{
             id
           }
@@ -37,7 +38,8 @@ RSpec.describe 'Update Composting Life Cycle Event Mutation', type: :graphql_mut
                                          input: {
                                            datetime: '2014-07-16T19:23:00Z',
                                            notes: 'newly updated record',
-                                           lifeCycleEventId: @life_cycle_event_id
+                                           lifeCycleEventId: @life_cycle_event_id,
+                                           deleted: true
                                          }
                                        })
     end
@@ -50,12 +52,12 @@ RSpec.describe 'Update Composting Life Cycle Event Mutation', type: :graphql_mut
       success_result = @result['data']['updateCompostingEvent']['compostingEvent']
       expect(success_result['notes']).to eq 'newly updated record'
       expect(success_result['id']).to eq @life_cycle_event_id
+      expect(success_result['deleted']).to eq true
 
       updated_event = LifeCycleEvent.find success_result['uuid']
       expect(updated_event).to_not be nil
       expect(updated_event.notes).to eq 'newly updated record'
+      expect(updated_event.deleted).to be true
     end
-  end
-  describe 'required parameters' do
   end
 end

--- a/spec/queries/composting_event_query_spec.rb
+++ b/spec/queries/composting_event_query_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Life Cycle Event Query', type: :graphql_query do
           id
           datetime
           notes
+          deleted
           specimen{
             id
           }
@@ -29,6 +30,7 @@ RSpec.describe 'Life Cycle Event Query', type: :graphql_query do
       expect(life_cycle_event_result['id']).to eq composting_event_id
       expect(life_cycle_event_result['notes']).to eq 'loaded by id'
       expect(life_cycle_event_result['__typename']).to eq 'CompostingEvent'
+      expect(life_cycle_event_result['deleted']).to be false
     end
   end
 end


### PR DESCRIPTION
Breaking Change: Life Cycle Events are now marked as deleted instead of being removed from the database.