### PR TITLE
Fix: Life Cycle Events don't have owned_by and visibility attributes

### DIFF
--- a/app/models/life_cycle_events/life_cycle_event.rb
+++ b/app/models/life_cycle_events/life_cycle_event.rb
@@ -19,6 +19,8 @@ class LifeCycleEvent < ApplicationRecord
   has_many :images, as: :imageable, dependent: :destroy
 
   belongs_to :specimen
+  delegate :owned_by, to: :specimen
+  delegate :visibility, to: :specimen
   belongs_to :location, optional: true
 
   def self.policy_class

--- a/spec/mutations/delete_image_spec.rb
+++ b/spec/mutations/delete_image_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe 'Delete Image Mutation', type: :graphql_mutation do
 
   context 'when user is not an admin' do
     let(:current_user) { build(:user, :readwrite) }
-    let(:image) { create(:image, owned_by: current_user.email, created_by: current_user.email, name: 'a name', description: 'a description') }
+    let(:specimen) { create(:specimen, owned_by: current_user.email, created_by: current_user.email) }
+    let(:lce) { create(:acquire_event, specimen: specimen) }
+    let(:image) { create(:image, imageable: lce, owned_by: current_user.email, created_by: current_user.email, name: 'a name', description: 'a description') }
 
     context 'when the user does not own the record' do
       let(:image) { create(:image, owned_by: 'notme', created_by: 'notme', name: 'a name', description: 'a description') }


### PR DESCRIPTION
Delegated owned_by and visibility in Life Cycle Events to the owning specimen