### PR TITLE
Fix: Implemented graphQL errors for deletion constraint violations

### DIFF
--- a/app/graphql/mutations/delete_category.rb
+++ b/app/graphql/mutations/delete_category.rb
@@ -20,7 +20,7 @@ module Mutations
       result = category.destroy
       errors = errors_from_active_record category.errors
       {
-        category_id: result.destroyed? ? id : nil,
+        category_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/graphql/mutations/delete_image.rb
+++ b/app/graphql/mutations/delete_image.rb
@@ -20,7 +20,7 @@ module Mutations
       result = image.destroy
       errors = errors_from_active_record image.errors
       {
-        image_id: result.destroyed? ? id : nil,
+        image_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/graphql/mutations/delete_location.rb
+++ b/app/graphql/mutations/delete_location.rb
@@ -20,7 +20,7 @@ module Mutations
       result = location.destroy
       errors = errors_from_active_record location.errors
       {
-        location_id: result.destroyed? ? id : nil,
+        location_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/graphql/mutations/delete_plant.rb
+++ b/app/graphql/mutations/delete_plant.rb
@@ -20,7 +20,7 @@ module Mutations
       result = plant.destroy
       errors = errors_from_active_record plant.errors
       {
-        plant_id: result.destroyed? ? id : nil,
+        plant_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/graphql/mutations/delete_specimen.rb
+++ b/app/graphql/mutations/delete_specimen.rb
@@ -20,7 +20,7 @@ module Mutations
       result = specimen.destroy
       errors = errors_from_active_record specimen.errors
       {
-        specimen_id: result.destroyed? ? id : nil,
+        specimen_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/graphql/mutations/delete_variety.rb
+++ b/app/graphql/mutations/delete_variety.rb
@@ -20,7 +20,7 @@ module Mutations
       result = variety.destroy
       errors = errors_from_active_record variety.errors
       {
-        variety_id: result.destroyed? ? id : nil,
+        variety_id: result ? id : nil,
         errors: errors
       }
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,7 +7,7 @@ class Location < ApplicationRecord
   enum soil_quality: { poor: 'poor', fair: 'fair', good: 'good' }, _prefix: :soil_quality
 
   has_many :images, as: :imageable, dependent: :destroy
-  has_many :life_cycle_events
+  has_many :life_cycle_events, dependent: :restrict_with_error
 
   def latitude=(latitude)
     if latlng.class == ActiveRecord::Point

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -22,9 +22,9 @@ class Plant < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   has_many :common_names, dependent: :destroy
 
-  has_many :varieties, dependent: :restrict_with_exception
+  has_many :varieties, dependent: :restrict_with_error
 
-  has_many :specimens
+  has_many :specimens, dependent: :restrict_with_error
 
   # default_scope { includes(:common_names) }
 

--- a/app/models/specimen.rb
+++ b/app/models/specimen.rb
@@ -7,5 +7,5 @@ class Specimen < ApplicationRecord
   validates :name, :owned_by, :created_by, :visibility, presence: true
   enum visibility: { private: 0, public: 1, draft: 2, deleted: 3 }, _prefix: :visibility
   has_many :images, as: :imageable, dependent: :destroy
-  has_many :life_cycle_events
+  has_many :life_cycle_events, dependent: :destroy
 end

--- a/app/models/variety.rb
+++ b/app/models/variety.rb
@@ -17,7 +17,7 @@ class Variety < ApplicationRecord
 
   belongs_to :plant
 
-  has_many :specimens
+  has_many :specimens, dependent: :restrict_with_error
 
   extend Mobility
   translates :name,

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -205,7 +205,16 @@ RSpec.describe Plant, type: :model do
     it 'fails if there are still variety records' do
       plant = create(:plant)
       create(:variety, plant: plant)
-      expect { plant.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      expect(plant.destroy).to be false
+      expect(plant.destroyed?).to be false
+      expect(plant.errors.count).to eq 1
+    end
+    it 'fails if there are still specimen records' do
+      plant = create(:plant)
+      create(:specimen, plant: plant)
+      expect(plant.destroy).to be false
+      expect(plant.destroyed?).to be false
+      expect(plant.errors.count).to eq 1
     end
   end
 end

--- a/spec/mutations/delete_specimen_spec.rb
+++ b/spec/mutations/delete_specimen_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Delete Specimen Mutation', type: :graphql_mutation do
+  let(:current_user) { nil }
+  let(:specimen) { create(:specimen) }
+  let(:query_string) {
+    <<-GRAPHQL
+		mutation($input: DeleteSpecimenInput!){
+			deleteSpecimen(input: $input){
+				specimenId
+				errors {
+          field
+          value
+          message
+          code
+        }
+			}
+		}
+    GRAPHQL
+  }
+
+  context 'when user is not authenticated' do
+    let(:current_user) { nil }
+    it 'returns an error when called' do
+      specimen_id = PlantApiSchema.id_from_object(specimen, Specimen, {})
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          specimenId: specimen_id
+                                        }
+                                      })
+      expect(result['data']).to be_nil
+      expect(result['errors']).to_not be_nil
+      expect(result['errors'].count).to eq 1
+      expect(result['errors'][0]['extensions']['code']).to eq 401
+    end
+  end
+
+  context 'when user is read only' do
+    let(:current_user) { build(:user, :readonly) }
+    it 'returns an error when called' do
+      specimen_id = PlantApiSchema.id_from_object(specimen, Specimen, {})
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          specimenId: specimen_id
+                                        }
+                                      })
+      expect(result['data']).to be_nil
+      expect(result['errors']).to_not be_nil
+      expect(result['errors'].count).to eq 1
+      expect(result['errors'][0]['extensions']['code']).to eq 403
+    end
+  end
+
+  context 'when user is not an admin' do
+    let(:current_user) { build(:user, :readwrite) }
+    let(:specimen) { create(:specimen, owned_by: current_user.email, created_by: current_user.email, name: 'a name') }
+
+    context 'when the user does not own the record' do
+      let(:specimen) { create(:specimen, owned_by: 'notme', created_by: 'notme', name: 'a name') }
+      it 'raises an error' do
+        @specimen_id = PlantApiSchema.id_from_object(specimen, Specimen, {})
+        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                          input: {
+                                            specimenId: @specimen_id
+                                          }
+                                        })
+        expect(result['data']).to be_nil
+        expect(result['errors']).to_not be_nil
+        expect(result['errors'].count).to eq 1
+        expect(result['errors'][0]['extensions']['code']).to eq 403
+      end
+    end
+    context 'when user owns the record' do
+      it 'deletes the record' do
+        specimen_id = PlantApiSchema.id_from_object(specimen, Specimen, {})
+        record_id = specimen.id
+        expect { Specimen.find record_id }.to_not raise_error(ActiveRecord::RecordNotFound)
+        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                          input: {
+                                            specimenId: specimen_id
+                                          }
+                                        })
+        expect(result).to_not include 'errors'
+        expect(result).to include 'data'
+        expect(result['data']['deleteSpecimen']).to include 'specimenId'
+        expect(result['data']['deleteSpecimen']['specimenId']).to eq specimen_id
+        expect { Specimen.find record_id }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+      context 'when there are related life cycle events' do
+        let(:acquire_event) { create(:acquire_event, specimen: specimen) }
+        let(:planting_event) { create(:planting_event, specimen: specimen) }
+        it 'deletes related life cycle events' do
+          specimen_id = PlantApiSchema.id_from_object(specimen, Specimen, {})
+          record_id = specimen.id
+          expect { Specimen.find record_id }.to_not raise_error(ActiveRecord::RecordNotFound)
+          expect(planting_event.specimen_id).to eq specimen.id
+          expect(acquire_event.specimen_id).to eq specimen.id
+          planting_event_id = planting_event.id
+          acquire_event_id = acquire_event.id
+          expect { LifeCycleEvent.find planting_event_id }.to_not raise_error(ActiveRecord::RecordNotFound)
+          expect { LifeCycleEvent.find acquire_event_id }.to_not raise_error(ActiveRecord::RecordNotFound)
+          result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                            input: {
+                                              specimenId: specimen_id
+                                            }
+                                          })
+          expect(result).to_not include 'errors'
+          expect(result).to include 'data'
+          expect(result['data']['deleteSpecimen']).to include 'specimenId'
+          expect(result['data']['deleteSpecimen']['specimenId']).to eq specimen_id
+          expect { Specimen.find record_id }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { LifeCycleEvent.find planting_event_id }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { LifeCycleEvent.find acquire_event_id }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Record deletion constraints now create graphQL errors for plants, varieties, and locations.

