### PR TITLE
Full plant/variety write surface, relation + common-name mutations

### DIFF
--- a/app/graphql/mutations/common_names/add_common_name.rb
+++ b/app/graphql/mutations/common_names/add_common_name.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Mutations
+  module CommonNames
+    # Adds a common name to a plant
+    class AddCommonName < BaseMutation
+      argument :plant_id, ID, required: true, loads: Types::PlantType
+      argument :name, String, required: true
+      argument :language, String, required: true
+      argument :location, String, required: false
+      argument :primary, Boolean, required: false, default_value: false
+
+      field :common_name, Types::CommonNameType, null: true
+      field :errors, [Types::MutationError], null: false
+
+      def authorized?(plant:, **_attributes)
+        authorize plant, :update?
+      end
+
+      def resolve(plant:, name:, language:, location: nil, primary: false)
+        language = language.upcase
+        common_name = plant.common_names.build(name: name, language: language, location: location, primary: primary)
+        CommonName.transaction do
+          plant.common_names.where(language: language, primary: true).update_all(primary: false) if primary
+          common_name.save
+        end
+        {
+          common_name: common_name.persisted? ? common_name : nil,
+          errors: errors_from_active_record(common_name.errors)
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/common_names/delete_common_name.rb
+++ b/app/graphql/mutations/common_names/delete_common_name.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  module CommonNames
+    # Deletes a common name
+    class DeleteCommonName < BaseMutation
+      argument :common_name_id, ID, required: true, loads: Types::CommonNameType
+
+      field :common_name_id, ID, null: true
+      field :errors, [Types::MutationError], null: false
+
+      def authorized?(common_name:, **_attributes)
+        authorize common_name.plant, :update?
+      end
+
+      def resolve(common_name:)
+        id = PlantApiSchema.id_from_object(common_name, CommonName, {})
+        result = common_name.destroy
+        {
+          common_name_id: result ? id : nil,
+          errors: errors_from_active_record(common_name.errors)
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/common_names/set_primary_common_name.rb
+++ b/app/graphql/mutations/common_names/set_primary_common_name.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Mutations
+  module CommonNames
+    # Makes a common name the primary name for its plant and language,
+    # demoting any current primary.
+    class SetPrimaryCommonName < BaseMutation
+      argument :common_name_id, ID, required: true, loads: Types::CommonNameType
+
+      field :common_name, Types::CommonNameType, null: true
+      field :errors, [Types::MutationError], null: false
+
+      def authorized?(common_name:, **_attributes)
+        authorize common_name.plant, :update?
+      end
+
+      def resolve(common_name:)
+        CommonName.transaction do
+          common_name.plant.common_names
+                     .where(language: common_name.language, primary: true)
+                     .where.not(id: common_name.id)
+                     .update_all(primary: false)
+          common_name.update(primary: true)
+        end
+        {
+          common_name: common_name,
+          errors: errors_from_active_record(common_name.errors)
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/common_names/update_common_name.rb
+++ b/app/graphql/mutations/common_names/update_common_name.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mutations
+  module CommonNames
+    # Modifies a common name's editable fields
+    class UpdateCommonName < BaseMutation
+      argument :common_name_id, ID, required: true, loads: Types::CommonNameType
+      argument :name, String, required: false
+      argument :location, String, required: false
+
+      field :common_name, Types::CommonNameType, null: true
+      field :errors, [Types::MutationError], null: false
+
+      def authorized?(common_name:, **_attributes)
+        authorize common_name.plant, :update?
+      end
+
+      def resolve(common_name:, **attributes)
+        common_name.update(attributes)
+        {
+          common_name: common_name,
+          errors: errors_from_active_record(common_name.errors)
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/concerns/plant_editable_arguments.rb
+++ b/app/graphql/mutations/concerns/plant_editable_arguments.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Concerns
+    # Declares the shared editable arguments for plant create/update mutations:
+    # all translatable text fields plus scalar characteristics.
+    module PlantEditableArguments
+      TRANSLATABLE_FIELDS = %i[
+        info_sheet_description origin uses cultivation harvesting_and_seed_production
+        pests_and_diseases cooking_and_nutrition attribution edible_green_leaves_note
+        edible_immature_fruit_note edible_mature_fruit_note used_for_fodder_note
+        tolerance_note antinutrient_note seeding_rate planting_instructions
+        asia_regional_info life_cycle_note n_accumulation_note biomass_production_note
+        optimal_temperature_note optimal_rainfall_note seasonality_note
+        early_growth_phase_note altitude_note ph_note growth_habits_note
+      ].freeze
+
+      BOOLEAN_FIELDS = %i[
+        has_edible_green_leaves has_edible_immature_fruit
+        has_edible_mature_fruit can_be_used_for_fodder
+      ].freeze
+
+      def self.included(base)
+        TRANSLATABLE_FIELDS.each do |name|
+          base.argument name, String, required: false,
+                                      description: "The translatable #{name.to_s.humanize.downcase} of the plant"
+        end
+        BOOLEAN_FIELDS.each do |name|
+          base.argument name, GraphQL::Types::Boolean, required: false
+        end
+        base.argument :early_growth_phase, Types::EarlyGrowthPhaseEnum, required: false
+        base.argument :life_cycle, Types::LifeCycleEnum, required: false
+        RangeLiteralValidation::RANGE_FIELDS.each do |name|
+          base.argument name, String, required: false,
+                                      description: 'Postgres range literal, e.g. "[0,10]"'
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/concerns/range_literal_validation.rb
+++ b/app/graphql/mutations/concerns/range_literal_validation.rb
@@ -17,9 +17,10 @@ module Mutations
           value = attributes[field]
           next if value.nil? || value.match?(RANGE_LITERAL)
 
+          camelized = field.to_s.camelize(:lower)
           {
-            field: field.to_s.camelize(:lower),
-            message: "#{field} is not a valid range literal (expected e.g. \"[0,10]\")",
+            field: camelized,
+            message: "#{camelized} is not a valid range literal (expected e.g. \"[0,10]\")",
             code: 400
           }
         end

--- a/app/graphql/mutations/concerns/range_literal_validation.rb
+++ b/app/graphql/mutations/concerns/range_literal_validation.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Concerns
+    # Validates Postgres range literal strings supplied to range arguments.
+    # Invalid literals become payload errors instead of raised cast errors.
+    module RangeLiteralValidation
+      RANGE_FIELDS = %i[
+        n_accumulation_range biomass_production_range optimal_temperature_range
+        optimal_rainfall_range seasonality_days_range optimal_altitude_range ph_range
+      ].freeze
+
+      RANGE_LITERAL = /\A[\[(]\s*-?\d*\.?\d*\s*,\s*-?\d*\.?\d*\s*[\])]\z/.freeze
+
+      def validate_range_literals(attributes)
+        RANGE_FIELDS.filter_map do |field|
+          value = attributes[field]
+          next if value.nil? || value.match?(RANGE_LITERAL)
+
+          {
+            field: field.to_s.camelize(:lower),
+            message: "#{field} is not a valid range literal (expected e.g. \"[0,10]\")",
+            code: 400
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/concerns/variety_editable_arguments.rb
+++ b/app/graphql/mutations/concerns/variety_editable_arguments.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Concerns
+    # Declares the shared editable arguments for variety create/update mutations.
+    # `name` and `description` are declared on the mutations themselves.
+    module VarietyEditableArguments
+      TRANSLATABLE_FIELDS = %i[
+        info_sheet_description origin uses cultivation harvesting_and_seed_production
+        pests_and_diseases cooking_and_nutrition attribution edible_green_leaves_note
+        edible_immature_fruit_note edible_mature_fruit_note used_for_fodder_note
+        tolerance_note antinutrient_note seeding_rate planting_instructions
+        asia_regional_info life_cycle_note n_accumulation_note biomass_production_note
+        optimal_temperature_note optimal_rainfall_note seasonality_note
+        early_growth_phase_note altitude_note ph_note growth_habits_note
+      ].freeze
+
+      BOOLEAN_FIELDS = %i[
+        has_edible_green_leaves has_edible_immature_fruit
+        has_edible_mature_fruit can_be_used_for_fodder
+      ].freeze
+
+      def self.included(base)
+        TRANSLATABLE_FIELDS.each do |name|
+          base.argument name, String, required: false,
+                                      description: "The translatable #{name.to_s.humanize.downcase} of the variety"
+        end
+        BOOLEAN_FIELDS.each do |name|
+          base.argument name, GraphQL::Types::Boolean, required: false
+        end
+        RangeLiteralValidation::RANGE_FIELDS.each do |name|
+          base.argument name, String, required: false,
+                                      description: 'Postgres range literal, e.g. "[0,10]"'
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/create_plant.rb
+++ b/app/graphql/mutations/create_plant.rb
@@ -22,6 +22,9 @@ module Mutations
              required: false,
              description: 'The visibility of the plant'
 
+    include Mutations::Concerns::PlantEditableArguments
+    include Mutations::Concerns::RangeLiteralValidation
+
     field :plant, Types::PlantType, null: true
     field :errors, [Types::MutationError], null: false
 
@@ -30,6 +33,9 @@ module Mutations
     end
 
     def resolve(**attributes) # rubocop:disable Metrics/AbcSize
+      range_errors = validate_range_literals(attributes)
+      return { plant: nil, errors: range_errors } if range_errors.any?
+
       language = attributes[:language] || I18n.locale
       primary_common_name = attributes[:primary_common_name]
 

--- a/app/graphql/mutations/create_variety.rb
+++ b/app/graphql/mutations/create_variety.rb
@@ -20,6 +20,9 @@ module Mutations
              required: false,
              description: 'The visibility of the variety'
 
+    include Mutations::Concerns::VarietyEditableArguments
+    include Mutations::Concerns::RangeLiteralValidation
+
     field :variety, Types::VarietyType, null: true
     field :errors, [Types::MutationError], null: false
 
@@ -27,7 +30,10 @@ module Mutations
       authorize Variety, :create?
     end
 
-    def resolve(**attributes)
+    def resolve(**attributes) # rubocop:disable Metrics/AbcSize
+      range_errors = validate_range_literals(attributes)
+      return { variety: nil, errors: range_errors } if range_errors.any?
+
       language = attributes[:language] || I18n.locale
 
       attributes

--- a/app/graphql/mutations/relations/update_plant_antinutrients.rb
+++ b/app/graphql/mutations/relations/update_plant_antinutrients.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of antinutrients linked to a plant
+    class UpdatePlantAntinutrients < UpdateRelationsBaseMutation
+      relates Plant, type: Types::PlantType, association: :antinutrients, items_type: Types::AntinutrientType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_plant_categories.rb
+++ b/app/graphql/mutations/relations/update_plant_categories.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of categories linked to a plant
+    class UpdatePlantCategories < UpdateRelationsBaseMutation
+      relates Plant, type: Types::PlantType, association: :categories, items_type: Types::CategoryType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_plant_growth_habits.rb
+++ b/app/graphql/mutations/relations/update_plant_growth_habits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of growth habits linked to a plant
+    class UpdatePlantGrowthHabits < UpdateRelationsBaseMutation
+      relates Plant, type: Types::PlantType, association: :growth_habits, items_type: Types::GrowthHabitType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_plant_tolerances.rb
+++ b/app/graphql/mutations/relations/update_plant_tolerances.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of tolerances linked to a plant
+    class UpdatePlantTolerances < UpdateRelationsBaseMutation
+      relates Plant, type: Types::PlantType, association: :tolerances, items_type: Types::ToleranceType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_relations_base_mutation.rb
+++ b/app/graphql/mutations/relations/update_relations_base_mutation.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Base mutation for set-style lookup relation updates on owned records
+    # (plant/variety <-> categories/tolerances/growth habits/antinutrients).
+    # The supplied id list replaces the association entirely.
+    class UpdateRelationsBaseMutation < BaseMutation
+      class << self
+        attr_reader :owner_key, :association
+
+        def relates(owner_class, type:, association:, items_type:)
+          @owner_key = owner_class.name.underscore.to_sym
+          @association = association
+          argument "#{@owner_key}_id".to_sym, GraphQL::Types::ID, required: true, loads: type
+          argument "#{association.to_s.singularize}_ids".to_sym, [GraphQL::Types::ID],
+                   required: true,
+                   loads: items_type,
+                   as: association,
+                   description: "Replaces the #{association} set. An empty list clears it."
+          field @owner_key, type, null: true
+          field :errors, [Types::MutationError], null: false
+        end
+      end
+
+      def authorized?(**attributes)
+        authorize attributes[self.class.owner_key], :update?
+      end
+
+      def resolve(**attributes)
+        owner = attributes[self.class.owner_key]
+        items = attributes[self.class.association]
+        owner.public_send("#{self.class.association}=", items)
+        {
+          self.class.owner_key => owner,
+          errors: errors_from_active_record(owner.errors)
+        }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_variety_antinutrients.rb
+++ b/app/graphql/mutations/relations/update_variety_antinutrients.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of antinutrients linked to a variety
+    class UpdateVarietyAntinutrients < UpdateRelationsBaseMutation
+      relates Variety, type: Types::VarietyType, association: :antinutrients, items_type: Types::AntinutrientType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_variety_growth_habits.rb
+++ b/app/graphql/mutations/relations/update_variety_growth_habits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of growth habits linked to a variety
+    class UpdateVarietyGrowthHabits < UpdateRelationsBaseMutation
+      relates Variety, type: Types::VarietyType, association: :growth_habits, items_type: Types::GrowthHabitType
+    end
+  end
+end

--- a/app/graphql/mutations/relations/update_variety_tolerances.rb
+++ b/app/graphql/mutations/relations/update_variety_tolerances.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  module Relations
+    # Replaces the set of tolerances linked to a variety
+    class UpdateVarietyTolerances < UpdateRelationsBaseMutation
+      relates Variety, type: Types::VarietyType, association: :tolerances, items_type: Types::ToleranceType
+    end
+  end
+end

--- a/app/graphql/mutations/update_plant.rb
+++ b/app/graphql/mutations/update_plant.rb
@@ -12,6 +12,9 @@ module Mutations
     argument :language, String, required: false
     argument :visibility, Types::VisibilityEnum, required: false
 
+    include Mutations::Concerns::PlantEditableArguments
+    include Mutations::Concerns::RangeLiteralValidation
+
     field :plant, Types::PlantType, null: true
     field :errors, [Types::MutationError], null: false
 
@@ -20,6 +23,9 @@ module Mutations
     end
 
     def resolve(plant:, **attributes) # rubocop:disable Metrics/AbcSize
+      range_errors = validate_range_literals(attributes)
+      return { plant: plant, errors: range_errors } if range_errors.any?
+
       language = attributes[:language] || I18n.locale
       primary_common_name = attributes[:primary_common_name]
 

--- a/app/graphql/mutations/update_variety.rb
+++ b/app/graphql/mutations/update_variety.rb
@@ -11,6 +11,9 @@ module Mutations
     argument :language, String, required: false
     argument :visibility, Types::VisibilityEnum, required: false
 
+    include Mutations::Concerns::VarietyEditableArguments
+    include Mutations::Concerns::RangeLiteralValidation
+
     field :variety, Types::VarietyType, null: true
     field :errors, [Types::MutationError], null: false
 
@@ -19,6 +22,9 @@ module Mutations
     end
 
     def resolve(variety:, **attributes)
+      range_errors = validate_range_literals(attributes)
+      return { variety: variety, errors: range_errors } if range_errors.any?
+
       language = attributes[:language] || I18n.locale
 
       Mobility.with_locale(language) do

--- a/app/graphql/plant_api_schema.rb
+++ b/app/graphql/plant_api_schema.rb
@@ -82,6 +82,8 @@ class PlantApiSchema < GraphQL::Schema
       Types::GrowthHabitType
     when Tolerance
       Types::ToleranceType
+    when CommonName
+      Types::CommonNameType
     when Plant
       Types::PlantType
     when Variety

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -267,5 +267,17 @@ module Types
     field :update_variety_antinutrients,
           mutation: Mutations::Relations::UpdateVarietyAntinutrients,
           description: "Replaces a variety's set of antinutrients"
+    field :add_common_name,
+          mutation: Mutations::CommonNames::AddCommonName,
+          description: 'Adds a common name to a plant'
+    field :update_common_name,
+          mutation: Mutations::CommonNames::UpdateCommonName,
+          description: 'Updates a common name'
+    field :delete_common_name,
+          mutation: Mutations::CommonNames::DeleteCommonName,
+          description: 'Deletes a common name'
+    field :set_primary_common_name,
+          mutation: Mutations::CommonNames::SetPrimaryCommonName,
+          description: 'Makes a common name the primary for its plant and language'
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -246,5 +246,17 @@ module Types
     field :update_movement_event,
           mutation: Mutations::LifeCycleEvents::UpdateMovementLifeCycleEvent,
           description: 'Updates a Movement life cycle event'
+    field :update_plant_categories,
+          mutation: Mutations::Relations::UpdatePlantCategories,
+          description: "Replaces a plant's set of categories"
+    field :update_plant_tolerances,
+          mutation: Mutations::Relations::UpdatePlantTolerances,
+          description: "Replaces a plant's set of tolerances"
+    field :update_plant_growth_habits,
+          mutation: Mutations::Relations::UpdatePlantGrowthHabits,
+          description: "Replaces a plant's set of growth habits"
+    field :update_plant_antinutrients,
+          mutation: Mutations::Relations::UpdatePlantAntinutrients,
+          description: "Replaces a plant's set of antinutrients"
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -258,5 +258,14 @@ module Types
     field :update_plant_antinutrients,
           mutation: Mutations::Relations::UpdatePlantAntinutrients,
           description: "Replaces a plant's set of antinutrients"
+    field :update_variety_tolerances,
+          mutation: Mutations::Relations::UpdateVarietyTolerances,
+          description: "Replaces a variety's set of tolerances"
+    field :update_variety_growth_habits,
+          mutation: Mutations::Relations::UpdateVarietyGrowthHabits,
+          description: "Replaces a variety's set of growth habits"
+    field :update_variety_antinutrients,
+          mutation: Mutations::Relations::UpdateVarietyAntinutrients,
+          description: "Replaces a variety's set of antinutrients"
   end
 end

--- a/app/graphql/types/variety_type/variety_translation_type.rb
+++ b/app/graphql/types/variety_type/variety_translation_type.rb
@@ -59,9 +59,13 @@ module Types
       field :seeding_rate, String,
             description: 'Translated information about the seeding rate for a variety',
             null: true
-      field :varietying_instructions, String,
-            description: 'Translated varietying instructions for a variety',
+      field :planting_instructions, String,
+            description: 'Translated planting instructions for a variety',
             null: true
+      field :varietying_instructions, String,
+            hash_key: :planting_instructions,
+            null: true,
+            deprecation_reason: 'Use plantingInstructions'
       field :asia_regional_info, String,
             description: 'Translated information about a variety that is specifically relevant to Asia',
             null: true

--- a/spec/factories/common_names.rb
+++ b/spec/factories/common_names.rb
@@ -2,10 +2,9 @@
 
 FactoryBot.define do
   factory :common_name do
-    sequence(:name) { |n| "Common Name #{n}" }
-    language { Faker::Address.country_code }
-    location { Faker::Address.country }
-    plant { build(:plant) }
+    name { Faker::Creature::Animal.name }
+    language { 'EN' }
     primary { false }
+    plant
   end
 end

--- a/spec/mutations/common_name_mutations_spec.rb
+++ b/spec/mutations/common_name_mutations_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Common name mutations', type: :graphql_mutation do
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:plant) { create(:plant, owned_by: current_user.email, created_by: current_user.email) }
+  let(:plant_gid) { PlantApiSchema.id_from_object(plant, Plant, {}) }
+
+  def execute(query, input)
+    PlantApiSchema.execute(query, context: { current_user: current_user }, variables: { input: input })
+  end
+
+  describe 'addCommonName' do
+    let(:query) do
+      <<-GRAPHQL
+        mutation($input: AddCommonNameInput!){
+          addCommonName(input: $input){
+            errors { field message code }
+            commonName { uuid name language location primary }
+          }
+        }
+      GRAPHQL
+    end
+
+    it 'adds a non-primary name, upcasing the language' do
+      result = execute(query, { plantId: plant_gid, name: 'Velvet bean', language: 'en' })
+      cn = result['data']['addCommonName']['commonName']
+      expect(cn['name']).to eq 'Velvet bean'
+      expect(cn['language']).to eq 'EN'
+      expect(cn['primary']).to be false
+    end
+
+    it 'demotes the existing primary when adding a new primary' do
+      existing = create(:common_name, plant: plant, language: 'EN', primary: true)
+      execute(query, { plantId: plant_gid, name: 'Mucuna', language: 'en', primary: true })
+      expect(existing.reload.primary).to be false
+      expect(plant.common_names.where(language: 'EN', primary: true).count).to eq 1
+    end
+
+    it 'rejects non-owners with 403' do
+      result = PlantApiSchema.execute(query, context: { current_user: build(:user, :readwrite) },
+                                             variables: { input: { plantId: plant_gid, name: 'X', language: 'en' } })
+      expect(result['errors'][0]['extensions']['code']).to eq 403
+    end
+
+    it 'returns a payload error for a blank name' do
+      result = execute(query, { plantId: plant_gid, name: '', language: 'en' })
+      expect(result['data']['addCommonName']['errors'][0]['field']).to eq 'name'
+    end
+  end
+
+  describe 'updateCommonName / deleteCommonName / setPrimaryCommonName' do
+    let!(:common_name) { create(:common_name, plant: plant, language: 'EN', primary: false) }
+    let(:cn_gid) { PlantApiSchema.id_from_object(common_name, CommonName, {}) }
+
+    it 'updates name and location' do
+      query = 'mutation($input: UpdateCommonNameInput!){ updateCommonName(input: $input){ commonName { name location } errors { message } } }'
+      result = execute(query, { commonNameId: cn_gid, name: 'Lablab', location: 'East Africa' })
+      cn = result['data']['updateCommonName']['commonName']
+      expect(cn['name']).to eq 'Lablab'
+      expect(cn['location']).to eq 'East Africa'
+    end
+
+    it 'deletes and returns the id' do
+      query = 'mutation($input: DeleteCommonNameInput!){ deleteCommonName(input: $input){ commonNameId errors { message } } }'
+      result = execute(query, { commonNameId: cn_gid })
+      expect(result['data']['deleteCommonName']['commonNameId']).to eq cn_gid
+      expect(CommonName.exists?(common_name.id)).to be false
+    end
+
+    it 'setPrimary promotes and demotes within the language' do
+      other_primary = create(:common_name, plant: plant, language: 'EN', primary: true)
+      query = 'mutation($input: SetPrimaryCommonNameInput!){ setPrimaryCommonName(input: $input){ commonName { primary } errors { message } } }'
+      result = execute(query, { commonNameId: cn_gid })
+      expect(result['data']['setPrimaryCommonName']['commonName']['primary']).to be true
+      expect(other_primary.reload.primary).to be false
+    end
+
+    it 'authorizes against the parent plant' do
+      query = 'mutation($input: DeleteCommonNameInput!){ deleteCommonName(input: $input){ commonNameId } }'
+      result = PlantApiSchema.execute(query, context: { current_user: build(:user, :readwrite) },
+                                             variables: { input: { commonNameId: cn_gid } })
+      expect(result['errors'][0]['extensions']['code']).to eq 403
+    end
+  end
+end

--- a/spec/mutations/create_plant_full_surface_spec.rb
+++ b/spec/mutations/create_plant_full_surface_spec.rb
@@ -36,9 +36,12 @@ RSpec.describe 'Create Plant full field surface', type: :graphql_mutation do
 
   it 'returns a payload error for malformed range literals' do
     query = 'mutation($input: CreatePlantInput!){ createPlant(input: $input){ errors { field code } plant { uuid } } }'
-    result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: {
-                                      input: { primaryCommonName: 'X', phRange: 'acidic' }
-                                    })
+    result = nil
+    expect {
+      result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: {
+                                        input: { primaryCommonName: 'X', phRange: 'acidic' }
+                                      })
+    }.not_to change(Plant, :count)
     errors = result['data']['createPlant']['errors']
     expect(errors[0]['field']).to eq 'phRange'
     expect(errors[0]['code']).to eq 400

--- a/spec/mutations/create_plant_full_surface_spec.rb
+++ b/spec/mutations/create_plant_full_surface_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create Plant full field surface', type: :graphql_mutation do
+  before :each do
+    Mobility.locale = nil
+  end
+
+  let(:current_user) { build(:user, :readwrite) }
+
+  it 'creates a plant with translatable, scalar, and range fields in one call' do
+    query = <<-GRAPHQL
+      mutation($input: CreatePlantInput!) {
+        createPlant(input: $input) {
+          errors { field message code }
+          plant { uuid uses lifeCycle optimalRainfallRange }
+        }
+      }
+    GRAPHQL
+    result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: {
+                                      input: {
+                                        primaryCommonName: 'Velvet bean',
+                                        uses: 'Green manure',
+                                        lifeCycle: 'ANNUAL',
+                                        optimalRainfallRange: '[400,2500]',
+                                        language: 'en'
+                                      }
+                                    })
+    plant_result = result['data']['createPlant']['plant']
+    created = Plant.find plant_result['uuid']
+    expect(created.uses).to eq 'Green manure'
+    expect(created.life_cycle).to eq 'annual'
+    expect(created.optimal_rainfall_range).to include 1000
+  end
+
+  it 'returns a payload error for malformed range literals' do
+    query = 'mutation($input: CreatePlantInput!){ createPlant(input: $input){ errors { field code } plant { uuid } } }'
+    result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: {
+                                      input: { primaryCommonName: 'X', phRange: 'acidic' }
+                                    })
+    errors = result['data']['createPlant']['errors']
+    expect(errors[0]['field']).to eq 'phRange'
+    expect(errors[0]['code']).to eq 400
+    expect(result['data']['createPlant']['plant']).to be_nil
+  end
+end

--- a/spec/mutations/create_variety_full_surface_spec.rb
+++ b/spec/mutations/create_variety_full_surface_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create Variety full field surface', type: :graphql_mutation do
+  before :each do
+    Mobility.locale = nil
+  end
+
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:plant) { create(:plant, :public) }
+  let(:plant_gid) { PlantApiSchema.id_from_object(plant, Plant, {}) }
+
+  it 'creates a variety with translatable and scalar fields in one call' do
+    query = <<-GRAPHQL
+      mutation($input: CreateVarietyInput!) {
+        createVariety(input: $input) {
+          errors { field message code }
+          variety { uuid name uses hasEdibleMatureFruit }
+        }
+      }
+    GRAPHQL
+    result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: {
+                                      input: {
+                                        plantId: plant_gid,
+                                        name: 'Early Giant',
+                                        uses: 'Fresh market',
+                                        hasEdibleMatureFruit: true,
+                                        language: 'en'
+                                      }
+                                    })
+    variety_result = result['data']['createVariety']['variety']
+    created = Variety.find variety_result['uuid']
+    expect(created.name).to eq 'Early Giant'
+    expect(created.uses).to eq 'Fresh market'
+    expect(created.has_edible_mature_fruit).to be true
+  end
+end

--- a/spec/mutations/plant_relation_mutations_spec.rb
+++ b/spec/mutations/plant_relation_mutations_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Plant relation set mutations', type: :graphql_mutation do
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updatePlantCategories', owner_factory: :plant, owner_key: 'plant',
+                  items_factory: :category, ids_key: 'categoryIds', association: :categories
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updatePlantTolerances', owner_factory: :plant, owner_key: 'plant',
+                  items_factory: :tolerance, ids_key: 'toleranceIds', association: :tolerances
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updatePlantGrowthHabits', owner_factory: :plant, owner_key: 'plant',
+                  items_factory: :growth_habit, ids_key: 'growthHabitIds', association: :growth_habits
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updatePlantAntinutrients', owner_factory: :plant, owner_key: 'plant',
+                  items_factory: :antinutrient, ids_key: 'antinutrientIds', association: :antinutrients
+end

--- a/spec/mutations/update_plant_full_surface_spec.rb
+++ b/spec/mutations/update_plant_full_surface_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update Plant full field surface', type: :graphql_mutation do
+  before :each do
+    Mobility.locale = nil
+  end
+
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:plant) { create(:plant, owned_by: current_user.email, created_by: current_user.email) }
+  let(:plant_gid) { PlantApiSchema.id_from_object(plant, Plant, {}) }
+
+  def execute(input)
+    query = <<-GRAPHQL
+      mutation($input: UpdatePlantInput!) {
+        updatePlant(input: $input) {
+          errors { field message code }
+          plant {
+            uuid uses cultivation lifeCycle earlyGrowthPhase
+            hasEdibleGreenLeaves optimalTemperatureRange phRange
+          }
+        }
+      }
+    GRAPHQL
+    PlantApiSchema.execute(query, context: { current_user: current_user },
+                                  variables: { input: { plantId: plant_gid }.merge(input) })
+  end
+
+  it 'updates newly exposed translatable fields in the requested language' do
+    execute(uses: 'Ground cover', cultivation: 'Direct seed', language: 'en')
+    execute(uses: 'Cobertura', language: 'es')
+    expect(plant.reload.uses).to eq 'Ground cover'
+    expect(plant.cultivation).to eq 'Direct seed'
+    Mobility.with_locale(:es) { expect(plant.uses).to eq 'Cobertura' }
+  end
+
+  it 'updates enum and boolean scalars' do
+    result = execute(lifeCycle: 'PERENNIAL', earlyGrowthPhase: 'FAST', hasEdibleGreenLeaves: true)
+    plant_result = result['data']['updatePlant']['plant']
+    expect(plant_result['lifeCycle']).to eq 'PERENNIAL'
+    expect(plant_result['earlyGrowthPhase']).to eq 'FAST'
+    expect(plant_result['hasEdibleGreenLeaves']).to be true
+    expect(plant.reload.life_cycle).to eq 'perennial'
+  end
+
+  it 'round-trips range literals' do
+    result = execute(optimalTemperatureRange: '[12,30]', phRange: '[5.5,7.5]')
+    plant_result = result['data']['updatePlant']['plant']
+    expect(plant_result['errors']).to be_nil if plant_result.key?('errors')
+    expect(plant.reload.optimal_temperature_range).to include 20
+    expect(plant.optimal_temperature_range).to_not include 40
+    expect(plant.ph_range).to include 6.0
+  end
+
+  it 'returns a payload error for malformed range literals without saving' do
+    original = plant.optimal_temperature_range
+    result = execute(optimalTemperatureRange: 'warm-ish')
+    errors = result['data']['updatePlant']['errors']
+    expect(errors[0]['field']).to eq 'optimalTemperatureRange'
+    expect(errors[0]['code']).to eq 400
+    expect(plant.reload.optimal_temperature_range).to eq original
+  end
+
+  it 'still rejects updates from non-owners' do
+    other = build(:user, :readwrite)
+    query = 'mutation($input: UpdatePlantInput!){ updatePlant(input: $input){ plant { uuid } } }'
+    result = PlantApiSchema.execute(query, context: { current_user: other },
+                                           variables: { input: { plantId: plant_gid, uses: 'x' } })
+    expect(result['errors'][0]['extensions']['code']).to eq 403
+  end
+end

--- a/spec/mutations/update_plant_full_surface_spec.rb
+++ b/spec/mutations/update_plant_full_surface_spec.rb
@@ -45,9 +45,7 @@ RSpec.describe 'Update Plant full field surface', type: :graphql_mutation do
   end
 
   it 'round-trips range literals' do
-    result = execute(optimalTemperatureRange: '[12,30]', phRange: '[5.5,7.5]')
-    plant_result = result['data']['updatePlant']['plant']
-    expect(plant_result['errors']).to be_nil if plant_result.key?('errors')
+    execute(optimalTemperatureRange: '[12,30]', phRange: '[5.5,7.5]')
     expect(plant.reload.optimal_temperature_range).to include 20
     expect(plant.optimal_temperature_range).to_not include 40
     expect(plant.ph_range).to include 6.0

--- a/spec/mutations/update_variety_full_surface_spec.rb
+++ b/spec/mutations/update_variety_full_surface_spec.rb
@@ -32,6 +32,29 @@ RSpec.describe 'Update Variety full field surface', type: :graphql_mutation do
     Mobility.with_locale(:es) { expect(variety.uses).to eq 'Producción en espaldera' }
   end
 
+  it 'round-trips plantingInstructions via translations' do
+    query = <<-GRAPHQL
+      mutation($input: UpdateVarietyInput!) {
+        updateVariety(input: $input) {
+          errors { field message code }
+          variety { translations { locale plantingInstructions } }
+        }
+      }
+    GRAPHQL
+    result = PlantApiSchema.execute(query,
+                                    context: { current_user: current_user },
+                                    variables: {
+                                      input: {
+                                        varietyId: variety_gid,
+                                        plantingInstructions: 'Sow after last frost',
+                                        language: 'en'
+                                      }
+                                    })
+    translations = result['data']['updateVariety']['variety']['translations']
+    en_translation = translations.find { |t| t['locale'] == 'en' }
+    expect(en_translation['plantingInstructions']).to eq 'Sow after last frost'
+  end
+
   it 'updates booleans and ranges' do
     result = execute(canBeUsedForFodder: true, optimalAltitudeRange: '[0,1500]')
     variety_result = result['data']['updateVariety']['variety']

--- a/spec/mutations/update_variety_full_surface_spec.rb
+++ b/spec/mutations/update_variety_full_surface_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update Variety full field surface', type: :graphql_mutation do
+  before :each do
+    Mobility.locale = nil
+  end
+
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:variety) { create(:variety, owned_by: current_user.email, created_by: current_user.email) }
+  let(:variety_gid) { PlantApiSchema.id_from_object(variety, Variety, {}) }
+
+  def execute(input)
+    query = <<-GRAPHQL
+      mutation($input: UpdateVarietyInput!) {
+        updateVariety(input: $input) {
+          errors { field message code }
+          variety { uuid uses canBeUsedForFodder optimalAltitudeRange }
+        }
+      }
+    GRAPHQL
+    PlantApiSchema.execute(query,
+                           context: { current_user: current_user },
+                           variables: { input: { varietyId: variety_gid }.merge(input) })
+  end
+
+  it 'updates translatable fields in the requested language' do
+    execute(uses: 'Trellised production', language: 'en')
+    execute(uses: 'Producción en espaldera', language: 'es')
+    expect(variety.reload.uses).to eq 'Trellised production'
+    Mobility.with_locale(:es) { expect(variety.uses).to eq 'Producción en espaldera' }
+  end
+
+  it 'updates booleans and ranges' do
+    result = execute(canBeUsedForFodder: true, optimalAltitudeRange: '[0,1500]')
+    variety_result = result['data']['updateVariety']['variety']
+    expect(variety_result['canBeUsedForFodder']).to be true
+    expect(variety.reload.optimal_altitude_range).to include 1000
+  end
+
+  it 'returns a payload error for malformed range literals without saving' do
+    original = variety.optimal_altitude_range
+    result = execute(optimalAltitudeRange: 'high')
+    errors = result['data']['updateVariety']['errors']
+    expect(errors[0]['field']).to eq 'optimalAltitudeRange'
+    expect(errors[0]['code']).to eq 400
+    expect(variety.reload.optimal_altitude_range).to eq original
+  end
+end

--- a/spec/mutations/variety_relation_mutations_spec.rb
+++ b/spec/mutations/variety_relation_mutations_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Variety relation set mutations', type: :graphql_mutation do
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updateVarietyTolerances', owner_factory: :variety, owner_key: 'variety',
+                  items_factory: :tolerance, ids_key: 'toleranceIds', association: :tolerances
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updateVarietyGrowthHabits', owner_factory: :variety, owner_key: 'variety',
+                  items_factory: :growth_habit, ids_key: 'growthHabitIds', association: :growth_habits
+  it_behaves_like 'a relation set mutation',
+                  field_name: 'updateVarietyAntinutrients', owner_factory: :variety, owner_key: 'variety',
+                  items_factory: :antinutrient, ids_key: 'antinutrientIds', association: :antinutrients
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require 'paper_trail/frameworks/rspec'
 require 'pundit/rspec'
 require 'support/shared_contexts/policy'
 require 'support/shared_examples/lookup_mutations'
+require 'support/shared_examples/relation_mutations'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/support/shared_examples/relation_mutations.rb
+++ b/spec/support/shared_examples/relation_mutations.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Shared examples for set-style relation mutations (updatePlantCategories etc.).
+# The supplied id list REPLACES the association; empty list clears it.
+RSpec.shared_examples 'a relation set mutation' do |field_name:, owner_factory:, owner_key:, items_factory:, ids_key:, association:| # rubocop:disable Metrics/ParameterLists
+  input_type = "#{field_name[0].upcase}#{field_name[1..]}Input"
+  query_string = <<-GRAPHQL
+    mutation($input: #{input_type}!){
+      #{field_name}(input: $input){
+        errors { field message code }
+        #{owner_key} { uuid }
+      }
+    }
+  GRAPHQL
+
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:owner) { create(owner_factory, owned_by: current_user.email, created_by: current_user.email) }
+  let(:owner_gid) { PlantApiSchema.id_from_object(owner, owner.class, {}) }
+  let!(:item_a) { create(items_factory) }
+  let!(:item_b) { create(items_factory) }
+
+  def item_gid(item)
+    PlantApiSchema.id_from_object(item, item.class, {})
+  end
+
+  it 'replaces the association with the supplied set' do
+    owner.public_send(association) << item_a
+    PlantApiSchema.execute(query_string, context: { current_user: current_user },
+                                         variables: { input: { "#{owner_key}Id" => owner_gid, ids_key => [item_gid(item_b)] } })
+    expect(owner.reload.public_send(association)).to contain_exactly(item_b)
+  end
+
+  it 'clears the association with an empty list' do
+    owner.public_send(association) << item_a
+    PlantApiSchema.execute(query_string, context: { current_user: current_user },
+                                         variables: { input: { "#{owner_key}Id" => owner_gid, ids_key => [] } })
+    expect(owner.reload.public_send(association)).to be_empty
+  end
+
+  it 'rejects non-owners with 403' do
+    result = PlantApiSchema.execute(query_string, context: { current_user: build(:user, :readwrite) },
+                                                  variables: { input: { "#{owner_key}Id" => owner_gid, ids_key => [] } })
+    expect(result['errors'][0]['extensions']['code']).to eq 403
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 backend enablement (spec §14 items 1–4), stacked on #39. Companion frontend PR: ECHOInternational/plant_data_admin_interface#2.

- **Full plant editing** — `CreatePlant`/`UpdatePlant` now accept all 28 translatable fields, the 4 edible/fodder booleans, both enums, and the 7 range columns via shared `Mutations::Concerns::PlantEditableArguments`; malformed range literals return payload 400s via `RangeLiteralValidation` (never raise)
- **Full variety editing** — same treatment via `VarietyEditableArguments` (correctly excludes lifeCycle/earlyGrowthPhase — no such columns)
- **Relation set mutations** — `updatePlantCategories/Tolerances/GrowthHabits/Antinutrients` + 3 variety twins via a `relates` base-class DSL; list replaces the set, empty clears, owner-authorized
- **Common-name management** — add/update/delete/setPrimary with parent-plant authorization and transactional primary demotion; `CommonName` added to `resolve_type`
- **Bug fix** — `varietyingInstructions` typo'd field (always resolved null) renamed to `plantingInstructions` with a deprecated compatibility alias

## Test plan

- 41 new RSpec examples (full-surface specs, shared relation examples, common-name specs incl. auth + round-trips)
- Full suite: 1215 examples, 0 failures; no new RuboCop offenses (80 pre-existing on untouched upstream files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz