### PR TITLE
Event node resolution + location coordinate clearing

### DIFF
--- a/app/graphql/mutations/update_location.rb
+++ b/app/graphql/mutations/update_location.rb
@@ -50,12 +50,35 @@ module Mutations
     end
 
     def resolve(location:, **attributes)
+      coord_errors = apply_coordinates(location, attributes)
+      return { location: location, errors: coord_errors } if coord_errors
+
       location.update(attributes)
-      errors = errors_from_active_record location.errors
-      {
-        location: location,
-        errors: errors
-      }
+      { location: location, errors: errors_from_active_record(location.errors) }
+    end
+
+    private
+
+    def explicit_nil?(attributes, key)
+      attributes.key?(key) && attributes[key].nil?
+    end
+
+    def apply_coordinates(location, attributes)
+      lat_nil = explicit_nil?(attributes, :latitude)
+      lng_nil = explicit_nil?(attributes, :longitude)
+      return unless lat_nil || lng_nil
+
+      return clear_coordinates(location, attributes) if lat_nil && lng_nil
+
+      nil_field = lat_nil ? 'latitude' : 'longitude'
+      [{ field: nil_field, message: 'latitude and longitude must be provided together', code: 400 }]
+    end
+
+    def clear_coordinates(location, attributes)
+      attributes.delete(:latitude)
+      attributes.delete(:longitude)
+      location.latlng = nil
+      nil
     end
   end
 end

--- a/app/graphql/plant_api_schema.rb
+++ b/app/graphql/plant_api_schema.rb
@@ -92,6 +92,8 @@ class PlantApiSchema < GraphQL::Schema
       Types::SpecimenType
     when Location
       Types::LocationType
+    when LifeCycleEvent
+      Types::LifeCycleEventType.resolve_type(obj, _ctx)
     else
       raise("Not Implemented: #{obj}")
     end

--- a/spec/mutations/update_location_spec.rb
+++ b/spec/mutations/update_location_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update Location Mutation', type: :graphql_mutation do
+  let(:current_user) { nil }
+  let(:location) { create(:location) }
+  let(:query_string) {
+    <<-GRAPHQL
+      mutation($input: UpdateLocationInput!){
+        updateLocation(input: $input){
+          location{
+            id
+            name
+            latitude
+            longitude
+          }
+          errors {
+            field
+            value
+            message
+            code
+          }
+        }
+      }
+    GRAPHQL
+  }
+
+  context 'when user is not authenticated' do
+    let(:current_user) { nil }
+    it 'returns an error when called' do
+      location_id = PlantApiSchema.id_from_object(location, Location, {})
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          locationId: location_id,
+                                          name: 'new name'
+                                        }
+                                      })
+      expect(result['data']).to be_nil
+      expect(result['errors']).to_not be_nil
+      expect(result['errors'].count).to eq 1
+      expect(result['errors'][0]['extensions']['code']).to eq 401
+    end
+  end
+
+  context 'when user is read only' do
+    let(:current_user) { build(:user, :readonly) }
+    it 'returns an error when called' do
+      location_id = PlantApiSchema.id_from_object(location, Location, {})
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          locationId: location_id,
+                                          name: 'new name'
+                                        }
+                                      })
+      expect(result['data']).to be_nil
+      expect(result['errors']).to_not be_nil
+      expect(result['errors'].count).to eq 1
+      expect(result['errors'][0]['extensions']['code']).to eq 403
+    end
+  end
+
+  context 'when user is not an admin' do
+    let(:current_user) { build(:user, :readwrite) }
+    let(:location) { create(:location, owned_by: current_user.email, created_by: current_user.email) }
+
+    context 'when the user does not own the record' do
+      let(:location) { create(:location, owned_by: 'notme', created_by: 'notme') }
+      it 'raises an error' do
+        location_id = PlantApiSchema.id_from_object(location, Location, {})
+        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                          input: {
+                                            locationId: location_id,
+                                            name: 'new name'
+                                          }
+                                        })
+        expect(result['data']).to be_nil
+        expect(result['errors']).to_not be_nil
+        expect(result['errors'].count).to eq 1
+        expect(result['errors'][0]['extensions']['code']).to eq 403
+      end
+    end
+
+    context 'when user owns the record' do
+      context 'clearing both latitude and longitude via explicit nulls' do
+        it 'sets latlng to nil and returns no errors' do
+          location_id = PlantApiSchema.id_from_object(location, Location, {})
+          expect(location.latlng).not_to be_nil
+          result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                            input: {
+                                              locationId: location_id,
+                                              latitude: nil,
+                                              longitude: nil
+                                            }
+                                          })
+          expect(result['data']).to_not be_nil
+          expect(result['data']['updateLocation']['errors']).to be_empty
+          expect(location.reload.latlng).to be_nil
+        end
+      end
+
+      context 'clearing only latitude (one-sided nil)' do
+        it 'returns a 400 payload error and does not save' do
+          location_id = PlantApiSchema.id_from_object(location, Location, {})
+          original_latlng = location.latlng
+          result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                            input: {
+                                              locationId: location_id,
+                                              latitude: nil
+                                            }
+                                          })
+          expect(result['data']).to_not be_nil
+          errors = result['data']['updateLocation']['errors']
+          expect(errors.count).to eq 1
+          expect(errors[0]['field']).to eq 'latitude'
+          expect(errors[0]['code']).to eq 400
+          expect(location.reload.latlng).to eq original_latlng
+        end
+      end
+
+      context 'clearing only longitude (one-sided nil)' do
+        it 'returns a 400 payload error and does not save' do
+          location_id = PlantApiSchema.id_from_object(location, Location, {})
+          original_latlng = location.latlng
+          result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                            input: {
+                                              locationId: location_id,
+                                              longitude: nil
+                                            }
+                                          })
+          expect(result['data']).to_not be_nil
+          errors = result['data']['updateLocation']['errors']
+          expect(errors.count).to eq 1
+          expect(errors[0]['field']).to eq 'longitude'
+          expect(errors[0]['code']).to eq 400
+          expect(location.reload.latlng).to eq original_latlng
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/life_cycle_event_node_spec.rb
+++ b/spec/queries/life_cycle_event_node_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Life cycle event node lookup', type: :graphql_query do
+  let(:current_user) { build(:user, :readwrite) }
+  let!(:specimen) { create(:specimen, :public) }
+  let!(:event) { create(:harvest_event, specimen: specimen) }
+  let(:event_gid) { PlantApiSchema.id_from_object(event, event.class, {}) }
+
+  it 'resolves an event through the node field' do
+    query = <<-GRAPHQL
+      query($id: ID!) {
+        node(id: $id) {
+          id
+          ... on HarvestEvent { uuid quantity }
+        }
+      }
+    GRAPHQL
+    result = PlantApiSchema.execute(query, context: { current_user: current_user }, variables: { id: event_gid })
+    expect(result['errors']).to be_nil
+    expect(result['data']['node']['uuid']).to eq event.id
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3 backend enablement, stacked on #40. Companion frontend PR: ECHOInternational/plant_data_admin_interface#3.

- **Fix: Relay `node(id:)` for life-cycle events** — `PlantApiSchema.resolve_type` raised "Not Implemented" for every event record (pre-existing since the events shipped); now delegates STI subclasses to the `LifeCycleEventType` interface's resolver
- **Feat: clearing location coordinates** — `updateLocation` previously could not clear `latlng` at all (explicit nulls broke the Postgres point cast with `(,)`). Now: both coordinates explicit-null → `latlng` cleared; one-sided null → payload 400 without saving (distinguishing explicit null from omitted argument)

## Test plan

- New specs: event node lookup; 6 updateLocation examples incl. clear-both and one-sided-null cases
- Full suite: 1222 examples, 0 failures; RuboCop clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz