### PR TITLE
fix(deploy): task-def JSON via temp file (file:///dev/stdin reads empty)

### DIFF
--- a/.github/scripts/deploy-ecs.sh
+++ b/.github/scripts/deploy-ecs.sh
@@ -26,14 +26,19 @@ SMOKE_URL=${5:-}
 
 register_revision() {
   local family=$1
+  # A real temp file: the AWS CLI cannot reliably read piped stdin via
+  # file:///dev/stdin (it re-opens the path, losing the pipe contents).
+  local tmp
+  tmp=$(mktemp)
   aws ecs describe-task-definition --task-definition "$family" \
     --query 'taskDefinition' --output json |
     jq --arg IMAGE "$IMAGE" '
       .containerDefinitions[0].image = $IMAGE
       | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
-            .compatibilities, .registeredAt, .registeredBy)' |
-    aws ecs register-task-definition --cli-input-json file:///dev/stdin \
-      --query 'taskDefinition.taskDefinitionArn' --output text
+            .compatibilities, .registeredAt, .registeredBy)' > "$tmp"
+  aws ecs register-task-definition --cli-input-json "file://$tmp" \
+    --query 'taskDefinition.taskDefinitionArn' --output text
+  rm -f "$tmp"
 }
 
 WEB_FAMILY=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \


### PR DESCRIPTION
Fixes the staging deploy failure in run 29064550790: the AWS CLI re-opens file:///dev/stdin rather than reading the pipe, so register-task-definition received empty input ('Invalid JSON received'). Writes the rendered task definition to a mktemp file instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz