### PR TITLE
fix(infra): ruby-based container health check (curl absent from slim image)

### DIFF
--- a/infra/envs/production/terraform.tfvars
+++ b/infra/envs/production/terraform.tfvars
@@ -6,7 +6,7 @@ aws_region     = "us-east-1"
 aws_account_id = "382724554857"
 
 # Image: updated by CI/CD pipeline on each deploy.
-image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:latest"
+image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:35c1bef18557"
 
 # ECS sizing (production: 2 tasks minimum)
 cpu           = 512

--- a/infra/envs/staging/terraform.tfvars
+++ b/infra/envs/staging/terraform.tfvars
@@ -7,7 +7,7 @@ aws_account_id = "382724554857"
 
 # Image: updated by CI/CD pipeline on each deploy.
 # Set to a placeholder — CI will pass -var="image=..." at apply time.
-image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:latest"
+image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:35c1bef18557"
 
 # ECS sizing (staging: minimum viable)
 cpu           = 256

--- a/infra/modules/plant-api/main.tf
+++ b/infra/modules/plant-api/main.tf
@@ -397,7 +397,10 @@ resource "aws_ecs_task_definition" "web" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+        # The production image is intentionally minimal and has no curl —
+        # a curl-based check fails on every task and ECS kills the (otherwise
+        # healthy) task after retries. Ruby is always present in this image.
+        command     = ["CMD-SHELL", "ruby -rnet/http -e 'exit(Net::HTTP.get_response(URI(\"http://127.0.0.1:3000/health\")).is_a?(Net::HTTPSuccess) ? 0 : 1)'"]
         interval    = 30
         timeout     = 5
         retries     = 3


### PR DESCRIPTION
The task-def container health check ran curl, which the minimal production image intentionally lacks — ECS killed every otherwise-healthy task ~2.5 minutes after its start-period ('Task failed container health checks'), causing the staging flapping and the run-29064795117 waiter timeout. Replaces it with a ruby -rnet/http one-liner (validated in the image) and pins tfvars images to the deployed SHA. Already applied to staging (task-def revision 4); this PR lands the same config in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz