### PR TITLE
fix(infra): production CORS parity with live EB (bare echocommunity.org origin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ yarn-debug.log*
 /spec/examples.txt
 
 coverage
+# Terraform saved plan files — may embed sensitive values, never commit
+*.tfplan

--- a/infra/envs/production/terraform.tfvars
+++ b/infra/envs/production/terraform.tfvars
@@ -62,7 +62,7 @@ db_secret_password_key = "password"
 images_s3_bucket = "images-us-east-1.echocommunity.org"
 
 # CORS origins — production
-cors_origins = "https://plant-api.echocommunity.org,https://plant-admin.echocommunity.org"
+cors_origins = "echocommunity.org,http://development.echocommunity.org:3000,https://plant-admin.echocommunity.org"
 
 # Observability — 90 days for production
 log_retention_days = 90


### PR DESCRIPTION
Pre-cutover EB-vs-ECS response diff caught that production CORS_ORIGINS omitted the bare echocommunity.org origin live EB grants (main-site in-browser tools depend on it). Fixed to EB parity + the future admin origin; already applied and verified — both backends now return identical CORS headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz