### PR TITLE
Rails upgrade Step 2: gem hygiene (puma 6.6, pg 1.5.9, jwt 2.10)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ ruby '~> 2.7.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
 # Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
+gem 'pg', '~> 1.5.9'
 # Use Puma as the app server
-gem 'puma', '~> 4.3.12'
+gem 'puma', '~> 6.6'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
@@ -23,9 +23,14 @@ gem 'puma', '~> 4.3.12'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.10', require: false
+# Pin concurrent-ruby to 1.1.x: Rails 6.0 references Logger via concurrent-ruby
+# and concurrent-ruby 1.2+ removes that constant (broken on Rails 6.0).
+# Drop this pin at upgrade Step 3 (Rails 6.1.7.10) - that version rewrites
+# LoggerThreadSafeLevel and no longer depends on concurrent-ruby's Logger constant.
+gem 'concurrent-ruby', '~> 1.1.10'
 
 # Authentication
-gem 'jwt'
+gem 'jwt', '~> 2.10'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
@@ -54,7 +59,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
-  gem 'faker'
+  gem 'faker', '~> 2.23'
   gem 'pundit-matchers'
   gem 'rspec-rails', '~> 4.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
@@ -92,17 +92,18 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faker (2.14.0)
-      i18n (>= 1.6, < 2)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphql (1.11.5)
     http_accept_language (2.1.1)
-    i18n (1.8.10)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    jwt (2.2.2)
+    jwt (2.10.3)
+      base64
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -131,8 +132,8 @@ GEM
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
-    puma (4.3.12)
+    pg (1.5.9)
+    puma (6.6.1)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
@@ -246,16 +247,17 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   bootsnap (>= 1.10)
   byebug
+  concurrent-ruby (~> 1.1.10)
   factory_bot_rails
-  faker
+  faker (~> 2.23)
   graphql (~> 1.9)
   http_accept_language
-  jwt
+  jwt (~> 2.10)
   listen (~> 3.2)
   mobility (~> 0.8.13)
   paper_trail (~> 10.3.1)
-  pg (>= 0.18, < 2.0)
-  puma (~> 4.3.12)
+  pg (~> 1.5.9)
+  puma (~> 6.6)
   pundit
   pundit-matchers
   rack-cors


### PR DESCRIPTION
Second rung of the Rails 6.0 → 8.1 ladder — newest gem versions that still support Ruby 2.7 + Rails 6.0:

| gem | before | after |
|---|---|---|
| puma | 4.3.12 | 6.6.1 (boot-verified single + cluster modes, /health 200) |
| pg | 1.2.3 | 1.5.9 |
| jwt | 2.2.2 | 2.10.3 (decode API surface verified against installed source) |
| faker | 2.14.0 | 2.23.0 (3.x needs Ruby ≥3.0; i18n 1.14.8 transitive) |
| concurrent-ruby | floating | **pinned ~>1.1.10** — 1.2+ breaks Rails 6.0 boot (Logger constant); Gemfile comment marks Step 3 (Rails 6.1.7.10) as the drop point |

Rails/graphql/rspec-rails/mobility/paper_trail/pundit/factory_bot deliberately untouched (later rungs). Suite 1271/0 incl. all contract specs; schema gate byte-clean. Reviewed (spec ✅ / quality approved; review's comment-wording finding applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz