### PR TITLE
Rails upgrade Step 7: mobility 1.2.9 (translations backend)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'http_accept_language'
 # Versioning
 gem 'paper_trail', '~> 12.3'
 # I18n
-gem 'mobility', '~> 0.8.13'
+gem 'mobility', '~> 1.2.9'
 # Graphql
 gem 'graphql', '~> 2.0.32'
 gem 'search_object_graphql', '~> 1.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.26.1)
-    mobility (0.8.13)
+    mobility (1.2.9)
       i18n (>= 0.6.10, < 2)
       request_store (~> 1.0)
     msgpack (1.8.3)
@@ -276,7 +276,7 @@ DEPENDENCIES
   http_accept_language
   jwt (~> 2.10)
   listen (~> 3.2)
-  mobility (~> 0.8.13)
+  mobility (~> 1.2.9)
   paper_trail (~> 12.3)
   pg (~> 1.5.9)
   puma (~> 6.6)

--- a/config/initializers/mobility.rb
+++ b/config/initializers/mobility.rb
@@ -1,92 +1,67 @@
 # frozen_string_literal: true
 
-Mobility.configure do |config|
-  # Sets the default backend to use in models. This can be overridden in models
-  # by passing +backend: ...+ to +translates+.
-  config.default_backend = :container
+# Mobility 1.x configuration (plugins DSL).
+#
+# Mobility 0.8 used a global Mobility.configure block with config.default_backend,
+# config.accessor_method, config.query_method and config.default_options[...]. In 1.x
+# that global config was removed in favour of this per-application plugins DSL, which is
+# still evaluated once at boot and applies to every model that calls +translates+.
+#
+# Each plugin below reproduces exactly the behaviour that was pinned on 0.8.13 by
+# spec/models/mobility_compat_spec.rb. Do not add/remove a plugin without re-running that
+# spec: a change here can silently alter fallbacks, presence, dirty tracking or the query
+# scope and serve wrong-language content while still returning 200.
+Mobility.configure do
+  plugins do
+    # Storage: single jsonb +translations+ column per table, shape {"locale" => {"attr" => v}}.
+    # This is the 0.8 config.default_backend = :container. Column name is the Mobility
+    # default (+translations+), matching the existing schema.
+    backend :container
 
-  # By default, Mobility uses the +translates+ class method in models to
-  # describe translated attributes, but you can configure this method to be
-  # whatever you like. This may be useful if using Mobility alongside another
-  # translation gem which uses the same method name.
-  config.accessor_method = :translates
+    # ORM integration (0.8 loaded this implicitly for ActiveRecord models).
+    active_record
 
-  # To query on translated attributes, you need to append a scope to your
-  # model. The name of this scope is +i18n+ by default, but this can be changed
-  # to something else.
-  config.query_method    = :i18n
+    # Attribute readers/writers. In 0.8 these were part of the default plugin set that
+    # backed +translates :field+ accessors.
+    reader
+    writer
 
-  # Uncomment and remove (or add) items to (from) this list to completely
-  # disable/enable plugins globally (so they cannot be used and are never even
-  # loaded). Note that if you remove an item from the list, you will not be
-  # able to use the plugin at all, and any options for the plugin will be
-  # ignored by models. (In most cases, you probably don't want to change this.)
-  #
-  # config.plugins = %i[
-  #   query
-  #   cache
-  #   dirty
-  #   fallbacks
-  #   presence
-  #   default
-  #   attribute_methods
-  #   fallthrough_accessors
-  #   locale_accessors
-  # ]
+    # Translation cache, ON by default in 0.8 (config.default_options[:cache] was left at
+    # its default). Keeps repeated reads within a request consistent.
+    cache
 
-  # The translation cache is on by default, but you can turn it off by
-  # uncommenting this line. (This may be helpful in debugging.)
-  #
-  # config.default_options[:cache] = false
+    # Dirty tracking. 0.8 had config.default_options[:dirty] = true. The dirty plugin also
+    # pulls in fallthrough_accessors, which is what makes the bare-attr dirty methods
+    # (e.g. pests_and_diseases_changed?, _change) work; PaperTrail versioning of translated
+    # changes rides on this. fallthrough_accessors is declared explicitly below to make the
+    # dependency visible.
+    dirty
 
-  # Dirty tracking is disabled by default. Uncomment this line to enable it.
-  # If you enable this, you should also enable +locale_accessors+ by default
-  # (see below).
-  #
-  config.default_options[:dirty] = true
+    # Fallbacks. 0.8 had config.default_options[:fallbacks] = true, which uses I18n.fallbacks
+    # (config.i18n.fallbacks = true in application.rb) / I18n.default_locale (:en). A bare
+    # +fallbacks+ here reproduces that: a missing locale falls back to the :en value.
+    fallbacks
 
-  # No fallbacks are used by default. To define default fallbacks, uncomment
-  # and set the default fallback option value here. A "true" value will use
-  # whatever is defined by +I18n.fallbacks+ (if defined), or alternatively will
-  # fallback to your +I18n.default_locale+.
-  #
-  config.default_options[:fallbacks] = true
+    # Presence. 0.8 shipped presence ON by default (config.default_options[:presence] was
+    # never set to false), converting "" to nil on read and write. Declared explicitly to
+    # preserve that blank-to-nil semantic (a known 0.8 -> 1.x drift point).
+    presence
 
-  # The Presence plugin converts empty strings to nil when fetching and setting
-  # translations. By default it is on, uncomment this line to turn it off.
-  #
-  # config.default_options[:presence] = false
+    # Locale accessors: 0.8 had config.default_options[:locale_accessors] = true. Use the
+    # application's available_locales so *_en / *_es style accessors are defined, matching
+    # the prior default (true -> Rails available_locales).
+    locale_accessors Rails.application.config.i18n.available_locales
 
-  # Set a default value to use if the translation is nil. By default this is
-  # off, uncomment and set a default to use it across all models (you probably
-  # don't want to do that).
-  #
-  # config.default_options[:default] = ...
+    # Fallthrough accessors: enabled implicitly by the dirty plugin in 0.8; declared here so
+    # the bare-attr dirty accessors keep working.
+    fallthrough_accessors
 
-  # Uncomment to enable locale_accessors by default on models. A true value
-  # will use the locales defined either in
-  # Rails.application.config.i18n.available_locales or I18n.available_locales.
-  # If you want something else, pass an array of locales instead.
-  #
-  config.default_options[:locale_accessors] = true
+    # Query scope. 0.8 had config.query_method = :i18n. The bare +query+ plugin defaults the
+    # scope name to +i18n+, which is exactly what every collection resolver uses.
+    query
 
-  # Uncomment to enable fallthrough accessors by default on models. This will
-  # allow you to call any method with a suffix like _en or _pt_br, and Mobility
-  # will catch the suffix and convert it into a locale in +method_missing+. If
-  # you don't need this kind of open-ended fallthrough behavior, it's better
-  # to use locale_accessors instead (which define methods) since method_missing
-  # is very slow. (You can use both fallthrough and locale accessor plugins
-  # together without conflict.)
-  #
-  # Note: The dirty plugin enables fallthrough_accessors by default.
-  #
-  # config.default_options[:fallthrough_accessors] = true
-
-  # You can also include backend-specific default options. For example, if you
-  # want to default to using the text-type translation table with the KeyValue
-  # backend, you can set that as a default by uncommenting this line, or change
-  # it to :string to default to the string-type translation table instead. (For
-  # other backends, this option is ignored.)
-  #
-  # config.default_options[:type] = :text
+    # 0.8 used config.accessor_method = :translates as the DSL entry point. In 1.x
+    # +extend Mobility; translates ...+ (already in the models) is the standard entry point,
+    # so no accessor_method override is needed.
+  end
 end

--- a/spec/models/mobility_compat_spec.rb
+++ b/spec/models/mobility_compat_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Compatibility guard for the mobility 0.8.13 -> 1.2.9 bump on frozen Rails 6.1 / Ruby 2.7.
+#
+# Mobility 0.8 -> 1.x rewrote configuration (a global Mobility.configure block became a
+# per-model plugins DSL). The danger of that bump is NOT a crash - it is SILENT SEMANTIC
+# DRIFT: fallbacks, presence (blank-vs-nil), dirty tracking, and locale-scoped queries can
+# change behaviour while every request still returns 200, just with wrong-language content.
+# This API serves translated plant data to external consumers in multiple locales.
+#
+# Every example below pins a behaviour AS OBSERVED ON 0.8.13 and each carries a one-line
+# comment naming the drift it guards. This spec is committed and proven green on 0.8 BEFORE
+# the gem bump, and must pass UNCHANGED afterwards. It is a tripwire: do not relax an
+# assertion to make 1.x pass - a red example here means a real semantic moved.
+RSpec.describe 'Mobility 1.x compatibility', type: :model do
+  before { Mobility.locale = nil }
+  after { Mobility.locale = nil }
+
+  # (a) DATA FORMAT: the raw jsonb container layout must stay {"locale" => {"attr" => v}}.
+  # The migration claim is "jsonb layout unchanged"; this proves it at the storage level.
+  describe 'raw storage layout (container backend)' do
+    it 'stores translations as a per-locale nested jsonb hash keyed by attribute' do
+      plant = create(:plant)
+      Mobility.with_locale(:en) { plant.origin = 'English origin' }
+      Mobility.with_locale(:es) { plant.origin = 'Origen espanol' }
+      plant.save!
+      plant.reload
+
+      raw = plant.read_attribute(:translations)
+
+      expect(raw).to be_a(Hash)
+      expect(raw['en']).to include('origin' => 'English origin')
+      expect(raw['es']).to eq('origin' => 'Origen espanol')
+      # attributes hash exposes the same raw container (not a decoded/locale-scoped view).
+      expect(plant.attributes['translations']).to eq(raw)
+    end
+  end
+
+  # (b) LOCALE READS: reading under an explicit locale returns that locale's value.
+  describe 'locale reads' do
+    it 'returns the value for the active locale' do
+      plant = create(:plant)
+      Mobility.with_locale(:en) { plant.origin = 'English origin' }
+      Mobility.with_locale(:es) { plant.origin = 'Origen espanol' }
+      plant.save!
+      plant.reload
+
+      expect(Mobility.with_locale(:en) { plant.origin }).to eq('English origin')
+      expect(Mobility.with_locale(:es) { plant.origin }).to eq('Origen espanol')
+    end
+  end
+
+  # (c) FALLBACKS: reading a missing locale falls back to the default locale (:en) value;
+  # a value present in NO locale reads as nil. Fallback config is a known 0.8->1.x drift point.
+  describe 'fallbacks' do
+    it 'falls back to the :en value when the requested locale is missing' do
+      plant = create(:plant)
+      Mobility.with_locale(:en) { plant.origin = 'English origin' }
+      plant.save!
+      plant.reload
+
+      # :es and :fr have no origin translation -> fall back to :en.
+      expect(Mobility.with_locale(:es) { plant.origin }).to eq('English origin')
+      expect(Mobility.with_locale(:fr) { plant.origin }).to eq('English origin')
+    end
+
+    it 'returns nil for an attribute translated in no locale at all' do
+      plant = create(:plant)
+      plant.save!
+      plant.reload
+
+      # :uses is never set in any locale -> nil, not "" and not a fallback ghost.
+      expect(Mobility.with_locale(:en) { plant.uses }).to be_nil
+      expect(Mobility.with_locale(:fr) { plant.uses }).to be_nil
+    end
+  end
+
+  # (d) PRESENCE: the presence plugin converts "" to nil on both read and write, and an
+  # empty string is NOT persisted into the raw container. This is a known 0.8->1.x drift point.
+  describe 'presence (blank-to-nil)' do
+    it 'reads "" back as nil and does not persist the empty string' do
+      plant = create(:plant)
+      Mobility.with_locale(:en) { plant.origin = 'English origin' }
+      plant.save!
+      plant.reload
+
+      Mobility.with_locale(:en) { plant.cultivation = '' }
+      # read of a just-set "" is nil (presence on the reader)
+      expect(Mobility.with_locale(:en) { plant.cultivation }).to be_nil
+
+      plant.save!
+      plant.reload
+      expect(Mobility.with_locale(:en) { plant.cultivation }).to be_nil
+      # "" never entered the raw container: the en hash has origin but no cultivation key.
+      expect(plant.read_attribute(:translations)['en']).not_to have_key('cultivation')
+    end
+  end
+
+  # (e) DIRTY: changing a translated attr marks the record dirty, exposes an
+  # [old, new] change tuple via the bare-attr accessor, tracks the locale-suffixed shadow
+  # attribute in changed_attributes, and clears on save. PaperTrail versioning of a
+  # translated change rides on this dirty machinery, so a version row must record it.
+  describe 'dirty tracking' do
+    it 'tracks a translated-attr change and clears it on save' do
+      Mobility.locale = :en
+      plant = create(:plant)
+      plant.reload
+      Mobility.locale = :en
+
+      plant.pests_and_diseases = 'new pest text'
+
+      expect(plant.changed?).to be(true)
+      # bare-attr dirty accessors work via fallthrough; tuple is [old, new].
+      expect(plant.pests_and_diseases_changed?).to be(true)
+      expect(plant.pests_and_diseases_change).to eq([nil, 'new pest text'])
+      # the change is carried on the locale-suffixed shadow attribute in changed_attributes.
+      expect(plant.changed_attributes.keys).to include('pests_and_diseases_en')
+
+      plant.save!
+      expect(plant.changed?).to be(false)
+    end
+
+    it 'records the translations change in a PaperTrail version on update', versioning: true do
+      Mobility.locale = :en
+      plant = create(:plant)
+      plant.reload
+      Mobility.locale = :en
+
+      PaperTrail.request.whodunnit = 'editor@example.org'
+
+      expect do
+        plant.update!(origin: 'Changed Origin EN')
+      end.to change { PaperTrail::Version.where(item_type: 'Plant').count }.by(1)
+
+      version = PaperTrail::Version.where(item_type: 'Plant').order(:created_at).last
+      expect(version.event).to eq('update')
+      object = PaperTrail.serializer.load(version.object)
+      # the versioned object payload carries the translations container (pre-update state).
+      expect(object).to have_key('translations')
+    end
+  end
+
+  # (f) QUERY / .i18n: a locale-scoped query matches a record under its own locale value and
+  # does NOT match the same record when a different locale is active. This is the scope every
+  # collection resolver relies on; a drift here silently cross-contaminates search by language.
+  describe 'query via the .i18n scope' do
+    it 'matches under the correct locale and not under a different locale' do
+      category = create(:category)
+      Mobility.with_locale(:en) { category.update!(name: 'Legumes') }
+      Mobility.with_locale(:es) { category.update!(name: 'Legumbres') }
+
+      en_hits = Mobility.with_locale(:en) { Category.i18n { name.eq('Legumes') }.to_a }
+      es_cross = Mobility.with_locale(:es) { Category.i18n { name.eq('Legumes') }.to_a }
+      es_hits = Mobility.with_locale(:es) { Category.i18n { name.eq('Legumbres') }.to_a }
+
+      expect(en_hits.map(&:id)).to include(category.id)
+      expect(es_cross.map(&:id)).not_to include(category.id) # no cross-locale leak
+      expect(es_hits.map(&:id)).to include(category.id)
+    end
+  end
+
+  # (g) GRAPHQL END-TO-END: what external consumers actually see. The single-plant query's
+  # `language` argument sets Mobility.locale; per-locale values come back correctly and a
+  # missing locale falls back to :en. This is the request-level guard against wrong-language 200s.
+  describe 'GraphQL request-level locale switching' do
+    it 'returns per-locale values and falls back for a missing locale' do
+      plant = create(:plant, :public)
+      Mobility.with_locale(:en) { plant.update!(origin: 'English Origin') }
+      Mobility.with_locale(:es) { plant.update!(origin: 'Origen Espanol') }
+      plant_id = PlantApiSchema.id_from_object(plant, Plant, {})
+
+      query = <<-GRAPHQL
+        query($id: ID!, $lang: String){
+          plant(id: $id, language: $lang){ id origin }
+        }
+      GRAPHQL
+
+      en = PlantApiSchema.execute(query, variables: { id: plant_id, lang: 'en' })
+      es = PlantApiSchema.execute(query, variables: { id: plant_id, lang: 'es' })
+      fr = PlantApiSchema.execute(query, variables: { id: plant_id, lang: 'fr' })
+
+      expect(en['data']['plant']['origin']).to eq('English Origin')
+      expect(es['data']['plant']['origin']).to eq('Origen Espanol')
+      # fr has no translation -> falls back to :en value, not nil, not es.
+      expect(fr['data']['plant']['origin']).to eq('English Origin')
+    end
+  end
+end


### PR DESCRIPTION
The silent-drift rung, done compat-spec-first:

- **Commit 1** (git-proven on mobility 0.8): new 9-example compat spec pinning raw jsonb container layout (frozen literal via `read_attribute` — bypasses the gem), per-locale reads, fallbacks (missing-locale vs never-translated, distinguished), presence blank→nil (with raw-column anchor), dirty tracking + PaperTrail version rows, `.i18n` locale isolation in both directions, and request-level GraphQL language switching
- **Commit 2**: mobility 0.8.13 → 1.2.9 + `config/initializers/mobility.rb` rewritten in the 1.x plugins DSL. The 0.8 IMPLICIT defaults (`presence`, `fallthrough_accessors`, `cache`) are now explicit and comment-flagged so they can't be silently trimmed. Zero model changes — all 8 `translates` declarations work unchanged
- The compat spec passes **unchanged** post-bump; reviewer verified the plugin mapping against the vendored 0.8 source and confirmed no dropped behavior

Only mobility moves in the lockfile. Suite 1285/0; 18 prior tripwires green; schema untouched. Reviewed (spec ✅ / quality approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz