### PR TITLE
Rails upgrade Step 12: graphql 2.3.23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'paper_trail', '~> 16.0'
 # I18n
 gem 'mobility', '~> 1.2.9'
 # Graphql
-gem 'graphql', '~> 2.0.32'
+gem 'graphql', '~> 2.3.23'
 gem 'search_object_graphql', '~> 1.0.5'
 # Authorization Policies
 gem 'pundit', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,10 +126,12 @@ GEM
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
+    fiber-storage (1.0.1)
     globalid (1.4.0)
       activesupport (>= 6.1)
-    graphql (2.0.32)
+    graphql (2.3.23)
       base64
+      fiber-storage
     http_accept_language (2.1.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
@@ -317,7 +319,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails (~> 6.4)
   faker (~> 3.5)
-  graphql (~> 2.0.32)
+  graphql (~> 2.3.23)
   http_accept_language
   jwt (~> 2.10)
   listen (~> 3.5)

--- a/schema.graphql
+++ b/schema.graphql
@@ -3217,7 +3217,7 @@ type HarvestEvent implements LifeCycleEvent & Node {
 """
 An ISO 8601-encoded datetime
 """
-scalar ISO8601DateTime
+scalar ISO8601DateTime @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")
 
 """
 Images can be associated with most data types in the Plant API


### PR DESCRIPTION
graphql minor-line advance, deliberately ceilinged below the 2.4 visibility-system rewrite (`~> 2.3.23` — post-ladder work starts clean: **zero** visibility warnings emitted at 2.3.23).

- Zero code changes — the Step 5/6 groundwork holds through 2.3
- Only movement: graphql + its new pure-Ruby `fiber-storage` dep; SOG stays 1.0.5
- SDL drift: exactly one line — the built-in `ISO8601DateTime` scalar now advertises `@specifiedBy(url: RFC-3339)`; implementer escalated per protocol, controller sign-off (graphql-inspector: 1 change, 0 breaking)
- **Frontend verification rung passed**: SPA codegen against this branch → generated TS provably order-only; suite 233/233
- Production-target image boot gate: `GRAPHQL_VERSION=2.3.23`, live SOG query with correct global IDs

Suite 1286/0; 28 tripwires green. Reviewed (spec ✅ / quality approved, zero findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz