### PR TITLE
Pre-promotion 3/4: coded-404 for malformed ids on all single-object queries

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -30,7 +30,7 @@ module Types
                required: true
     end
     def life_cycle_event(id:)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Pundit.policy_scope(context[:current_user], LifeCycleEvent).find(item_id)
     end
     field :plant, Types::PlantType, null: true do
@@ -44,7 +44,7 @@ module Types
                description: 'Request returned fields in a specific languge. Overrides ACCEPT-LANGUAGE header.'
     end
     def plant(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Pundit.policy_scope(context[:current_user], Plant).find(item_id)
     end
@@ -59,7 +59,7 @@ module Types
                description: 'Request returned fields in a specific languge. Overrides ACCEPT-LANGUAGE header.'
     end
     def variety(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Pundit.policy_scope(context[:current_user], Variety).find(item_id)
     end
@@ -75,7 +75,7 @@ module Types
                description: 'Request returned fields in a specific languge. Overrides ACCEPT-LANGUAGE header.'
     end
     def category(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Pundit.policy_scope(context[:current_user], Category).find(item_id)
     end
@@ -91,7 +91,7 @@ module Types
                description: 'Request returned fields in a specific languge. Overrides ACCEPT-LANGUAGE header.'
     end
     def specimen(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Pundit.policy_scope(context[:current_user], Specimen).find(item_id)
     end
@@ -107,7 +107,7 @@ module Types
                description: 'Request returned fields in a specific languge. Overrides ACCEPT-LANGUAGE header.'
     end
     def location(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Pundit.policy_scope(context[:current_user], Location).find(item_id)
     end
@@ -123,7 +123,7 @@ module Types
                description: 'Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.'
     end
     def image_attribute(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       ImageAttribute.find(item_id)
     end
@@ -139,7 +139,7 @@ module Types
                description: 'Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.'
     end
     def antinutrient(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Antinutrient.find(item_id)
     end
@@ -155,7 +155,7 @@ module Types
                description: 'Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.'
     end
     def tolerance(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       Tolerance.find(item_id)
     end
@@ -171,9 +171,28 @@ module Types
                description: 'Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.'
     end
     def growth_habit(id:, language: nil)
-      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id = decode_global_id(id)
       Mobility.locale = language || I18n.locale
       GrowthHabit.find(item_id)
+    end
+
+    private
+
+    # Decodes a Relay global ID, matching the error shape of PlantApiSchema.object_from_id
+    # so that malformed IDs on single-object queries yield the same coded 404 as the node()
+    # field (unified at pre-promo 3; was a raw 500 on Rails 6 production).
+    def decode_global_id(id)
+      _type_name, item_id = GraphQL::Schema::UniqueWithinType.decode(id)
+      item_id
+    rescue ArgumentError, GraphQL::ExecutionError
+      # graphql-ruby's base64 decoder raises ArgumentError on a malformed id in some
+      # versions and wraps it as a bare GraphQL::ExecutionError (no extensions.code)
+      # in others. Rescue both to guarantee a coded 404 regardless of which exception
+      # the decoder surfaces (mirrors the dual-class rescue in object_from_id).
+      raise GraphQL::ExecutionError.new(
+        "Not Found: #{id} not found. The provided ID is in an invalid format.",
+        extensions: { 'code' => 404 }
+      )
     end
   end
 end

--- a/spec/contracts/error_code_contract_spec.rb
+++ b/spec/contracts/error_code_contract_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe 'Error code contract', type: :request do
       expect(error_code(response)).to eq(404)
       expect(JSON.parse(response.body).dig('errors', 0, 'message')).not_to be_empty
     end
+
+    # Pins the inline-decode path's coded-404 (unified with node() at pre-promo 3;
+    # was a raw 500 on Rails 6 production). QueryType#plant and all other single-object
+    # resolvers now route through decode_global_id which mirrors object_from_id's rescue.
+    it 'returns 404 for a malformed (undecodable) global id via a single-object query (plant)' do
+      post '/graphql', params: { query: '{ plant(id: "not-base64!!") { id } }' }
+
+      expect(error_code(response)).to eq(404)
+      expect(JSON.parse(response.body).dig('errors', 0, 'message')).not_to be_empty
+    end
   end
 
   describe '403 forbidden' do


### PR DESCRIPTION
Unifies the malformed-global-id error contract: every single-object query (`plant(id:)`, `variety(id:)`, etc. — **all 10** inline-decode sites, not the 7 estimated) now routes through a `decode_global_id` helper whose rescue, message, and `extensions: { code: 404 }` shape are byte-identical to `node()`'s `object_from_id` path. On Rails-6 production this path was a raw HTTP 500; it's now the same clean 404 everywhere.

Happy paths verified untouched at every call site (single-line substitutions; locale + policy-scope logic byte-identical); valid-id-wrong-type behavior unchanged; schema SDL byte-identical. One authorized contract-spec addition pins the new path. Suite 1297/0. Reviewed (spec ✅ / quality approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz