### PR TITLE
Close #38: Elastic Beanstalk decommissioned

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,14 @@
 # ECHO Plant API — ECS Infrastructure
 
+> **HISTORICAL NOTE (2026-07-11): Elastic Beanstalk is DECOMMISSIONED.**
+> The environment was terminated on 2026-07-11 after the ECS cutover
+> (2026-07-10) and the Rails 8.1 promotion (2026-07-11). Sections below that
+> reference EB, the priority-15/16 listener rules, or EB-sourced secrets are
+> retained for historical context only. Rollback today = re-run the Deploy
+> workflow (workflow_dispatch) with a previously built git SHA. The
+> plantapi_app DB role now uses scram-sha-256 (the md5 workaround died with
+> EB's old libpq - see issue #38).
+
 Terraform infrastructure for migrating the ECHO Plant API from Elastic Beanstalk to Amazon ECS
 (Fargate). All resources are in **us-east-1**, account **382724554857**.
 

--- a/infra/envs/production/terraform.tfvars
+++ b/infra/envs/production/terraform.tfvars
@@ -24,7 +24,7 @@ alb_security_group_id = "sg-0ea89191a2ca2065a"
 alb_listener_arn      = "arn:aws:elasticloadbalancing:us-east-1:382724554857:listener/app/ECHOcommunity-load-balancer/cda099b79e56784d/6f2b7bd42f572512"
 
 # CUTOVER STRATEGY:
-#   The existing priority-15 rule currently forwards plant-api.echocommunity.org
+#   HISTORICAL (pre-2026-07-11, EB now decommissioned): the priority-15/16 EB rules
 #   traffic to the EB target group (awseb-echoplan-default-em2rm).
 #
 #   This Terraform config creates a new target group + listener rule at priority 19


### PR DESCRIPTION
The re-platform issue's full checklist is complete:

- [x] Containerize + bump Ruby off EOL 2.7 (Ruby 3.4.10 / Rails 8.1.3 in production) + refresh pg/libpq (pg 1.6.3, vendored libpq 18)
- [x] Source-vs-deployed reconciliation (cutover-day schema diff: purely additive)
- [x] ECS Fargate + ALB + secrets injection (live since 2026-07-10, Rails 8.1 since 2026-07-11)
- [x] Cutover (ALB host rule; DNS untouched)
- [x] **plantapi_app rotated back to scram-sha-256** (proven via `channel_binding=require` login; staging role was already SCRAM)
- [x] EB environment terminated 2026-07-11 (its priority-15/16 rules + target group removed cleanly); CodePipeline deleted
- [ ] → Rotation *schedule*: split out — no rotation lambda exists for ANY account secret today, so scheduled rotation is account-level infrastructure work, not plant-api-specific; the credential is now SCRAM and force-new-deployment rotation works (exercised today)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz