### PR TITLE
Perf: eliminate the mobile cache query's 953-query N+1 (2.5s -> ~170ms)

### DIFF
--- a/app/graphql/resolvers/plants_resolver.rb
+++ b/app/graphql/resolvers/plants_resolver.rb
@@ -84,10 +84,16 @@ module Resolvers
     def apply_name_filter(scope, value)
       return scope if value.blank?
 
-      scope
-        .includes(:common_names)
-        .where('common_names.name iLIKE ?', "%#{value}%")
-        .references(:common_names)
+      # Filter via an EXISTS subquery instead of joining/referencing the
+      # eager-loaded common_names association. A referenced where would turn the
+      # includes into a filtered LEFT JOIN and truncate the loaded association
+      # to only the matching rows, corrupting the loaded-aware
+      # primary_common_name tier resolution. The subquery keeps the outer
+      # includes(:common_names) loading the FULL association.
+      scope.where(
+        'EXISTS (SELECT 1 FROM common_names cn WHERE cn.plant_id = plants.id AND cn.name iLIKE :search)',
+        search: "%#{value}%"
+      )
     end
 
     def apply_scientific_name_filter(scope, value)
@@ -99,10 +105,15 @@ module Resolvers
     def apply_any_name_filter(scope, value)
       return scope if value.blank?
 
-      scope
-        .includes(:common_names)
-        .where('common_names.name iLIKE :search OR scientific_name iLIKE :search', { search: "%#{value}%" })
-        .references(:common_names)
+      # Match on scientific_name OR any common name via an EXISTS subquery so the
+      # eager-loaded common_names association is not truncated to matching rows
+      # (see apply_name_filter). The outer includes(:common_names) still loads
+      # the FULL association, keeping loaded-aware primary_common_name correct.
+      scope.where(
+        'plants.scientific_name iLIKE :search OR ' \
+        'EXISTS (SELECT 1 FROM common_names cn WHERE cn.plant_id = plants.id AND cn.name iLIKE :search)',
+        search: "%#{value}%"
+      )
     end
 
     def apply_language_filter(scope, _value)

--- a/app/graphql/resolvers/plants_resolver.rb
+++ b/app/graphql/resolvers/plants_resolver.rb
@@ -10,7 +10,14 @@ module Resolvers
     type Types::PlantType::PlantConnectionWithTotalCountType, null: false
     description 'Returns a list of Plants'
 
-    scope { Pundit.policy_scope(context[:current_user], Plant).i18n }
+    # Eager-load the two associations the list/detail responses read per plant
+    # (primary_common_name resolves over common_names; the nested varieties
+    # connection resolves through the varieties association). Without this the
+    # mobile cache-priming query issues one common_names query per plant plus
+    # one varieties query per plant (the classic N+1). Rails de-duplicates this
+    # against the additional includes(:common_names) added by the name/any_name
+    # filters, so those branches keep working.
+    scope { Pundit.policy_scope(context[:current_user], Plant).i18n.includes(:common_names, :varieties) }
 
     option :language,
            type: String,

--- a/app/graphql/types/plant_type.rb
+++ b/app/graphql/types/plant_type.rb
@@ -210,7 +210,29 @@ module Types
     end
 
     def varieties
-      Pundit.policy_scope(context[:current_user], @object.varieties)
+      user = context[:current_user]
+      # When the plants list resolver has eager-loaded :varieties, filter the
+      # in-memory records with the same rules Pundit's policy_scope would apply
+      # (OwnedResourcePolicy::Scope) instead of issuing a fresh per-plant query.
+      # This preserves the exact visible set while eliminating the N+1. When the
+      # association is not loaded (single-plant contexts) fall back to the SQL
+      # policy_scope so we don't force-load the association.
+      if @object.association(:varieties).loaded?
+        policy_scope_loaded(user, @object.varieties.to_a)
+      else
+        Pundit.policy_scope(user, @object.varieties)
+      end
+    end
+
+    # In-Ruby mirror of OwnedResourcePolicy::Scope#resolve for a loaded array.
+    def policy_scope_loaded(user, records)
+      if user&.admin?
+        records
+      elsif user
+        records.select { |r| r.visibility_public? || r.owned_by == user.email }
+      else
+        records.select(&:visibility_public?)
+      end
     end
 
     # def versions

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -74,17 +74,27 @@ class Plant < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # Resolves the display name for a plant in +locale+, applying a fixed
+  # fallback precedence (highest priority first):
+  #   1. requested language, primary == true
+  #   2. 'EN', primary == true
+  #   3. 'EN', any (primary true or false)
+  #   4. nil
+  # Within each tier the first match wins. "First" means ActiveRecord's
+  # implicit primary-key ordering (ORDER BY common_names.id ASC), because the
+  # underlying association queries call bare +.first+ with no explicit order.
+  #
+  # When the common_names association is already loaded (list/eager-loaded
+  # contexts), the tiers are resolved entirely in Ruby over the in-memory
+  # array — zero SQL — while reproducing the same precedence and ordering as
+  # the SQL path. When it is not loaded, the original per-tier SQL is used so
+  # single-record contexts are not forced to load the full association.
   def primary_common_name_for_locale(locale)
-    requested = common_names.where(language: locale.upcase).where(primary: true).first
-    return requested.name if requested
-
-    fallback = common_names.where(language: 'EN').where(primary: true).first
-    return fallback.name if fallback
-
-    default = common_names.where(language: 'EN').first
-    return default.name if default
-
-    nil
+    if common_names.loaded?
+      primary_common_name_from_loaded(locale)
+    else
+      primary_common_name_from_sql(locale)
+    end
   end
 
   def primary_common_name
@@ -125,5 +135,42 @@ class Plant < ApplicationRecord # rubocop:disable Metrics/ClassLength
         growth_habits_note: attributes['growth_habits_note']
       }
     end
+  end
+
+  private
+
+  # SQL path: preserves the original behavior exactly. Each tier runs its own
+  # query and relies on ActiveRecord's implicit primary-key ordering for +.first+.
+  def primary_common_name_from_sql(locale)
+    requested = common_names.where(language: locale.upcase).where(primary: true).first
+    return requested.name if requested
+
+    fallback = common_names.where(language: 'EN').where(primary: true).first
+    return fallback.name if fallback
+
+    default = common_names.where(language: 'EN').first
+    return default.name if default
+
+    nil
+  end
+
+  # Loaded path: resolves the same tiers over the in-memory association with
+  # zero SQL. +min_by(&:id)+ reproduces the SQL path's implicit ORDER BY id ASC
+  # so the chosen record (and thus the returned name) is byte-identical.
+  def primary_common_name_from_loaded(locale)
+    names = common_names.to_a
+    requested_lang = locale.to_s.upcase
+
+    requested = names.select { |cn| cn.language == requested_lang && cn.primary }.min_by(&:id)
+    return requested.name if requested
+
+    en = names.select { |cn| cn.language == 'EN' }
+    fallback = en.select(&:primary).min_by(&:id)
+    return fallback.name if fallback
+
+    default = en.min_by(&:id)
+    return default.name if default
+
+    nil
   end
 end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -158,19 +158,23 @@ class Plant < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # zero SQL. +min_by(&:id)+ reproduces the SQL path's implicit ORDER BY id ASC
   # so the chosen record (and thus the returned name) is byte-identical.
   def primary_common_name_from_loaded(locale)
-    names = common_names.to_a
     requested_lang = locale.to_s.upcase
+    en = in_language(common_names.to_a, 'EN')
 
-    requested = names.select { |cn| cn.language == requested_lang && cn.primary }.min_by(&:id)
-    return requested.name if requested
+    match = first_by_id(in_language(common_names.to_a, requested_lang).select(&:primary)) ||
+            first_by_id(en.select(&:primary)) ||
+            first_by_id(en)
 
-    en = names.select { |cn| cn.language == 'EN' }
-    fallback = en.select(&:primary).min_by(&:id)
-    return fallback.name if fallback
+    match&.name
+  end
 
-    default = en.min_by(&:id)
-    return default.name if default
+  def in_language(records, language)
+    records.select { |cn| cn.language == language }
+  end
 
-    nil
+  # Picks the record with the lowest id, matching the SQL path's implicit
+  # ORDER BY id ASC used by bare +.first+.
+  def first_by_id(records)
+    records.min_by(&:id)
   end
 end

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -217,4 +217,83 @@ RSpec.describe Plant, type: :model do
       expect(plant.errors.count).to eq 1
     end
   end
+
+  describe '#primary_common_name_for_locale' do
+    # The fixed fallback precedence, highest priority first:
+    #   1. requested language, primary == true
+    #   2. 'EN', primary == true
+    #   3. 'EN', any (primary true or false)
+    #   4. nil
+    # Within each tier, ActiveRecord's implicit ORDER BY id ASC picks the winner.
+    #
+    # These examples run each case twice: once with the common_names association
+    # NOT loaded (the SQL path) and once with it loaded (the Ruby path), proving
+    # both paths return byte-identical results.
+    def resolve_both_ways(plant, locale)
+      plant.reload # ensure the association is not loaded (SQL path)
+      raise 'expected association to be unloaded' if plant.association(:common_names).loaded?
+
+      sql_result = plant.primary_common_name_for_locale(locale)
+
+      plant.common_names.load # force the association to load (Ruby path)
+      raise 'expected association to be loaded' unless plant.association(:common_names).loaded?
+
+      loaded_result = plant.primary_common_name_for_locale(locale)
+
+      expect(loaded_result).to eq(sql_result)
+      sql_result
+    end
+
+    it 'prefers the requested-language primary name (tier 1)' do
+      plant = create(:plant)
+      create(:common_name, plant: plant, name: 'Spanish Primary', language: 'ES', primary: true)
+      create(:common_name, plant: plant, name: 'Spanish Other', language: 'ES', primary: false)
+      create(:common_name, plant: plant, name: 'English Primary', language: 'EN', primary: true)
+
+      expect(resolve_both_ways(plant, 'es')).to eq 'Spanish Primary'
+    end
+
+    it 'falls back to the EN primary name when the requested language has no primary (tier 2)' do
+      plant = create(:plant)
+      create(:common_name, plant: plant, name: 'Spanish Other', language: 'ES', primary: false)
+      create(:common_name, plant: plant, name: 'English Primary', language: 'EN', primary: true)
+      create(:common_name, plant: plant, name: 'English Other', language: 'EN', primary: false)
+
+      expect(resolve_both_ways(plant, 'es')).to eq 'English Primary'
+    end
+
+    it 'falls back to any EN name when there is no EN primary (tier 3)' do
+      plant = create(:plant)
+      create(:common_name, plant: plant, name: 'Spanish Other', language: 'ES', primary: false)
+      create(:common_name, plant: plant, name: 'English Other', language: 'EN', primary: false)
+
+      expect(resolve_both_ways(plant, 'es')).to eq 'English Other'
+    end
+
+    it 'returns nil when there is no matching name (tier 4)' do
+      plant = create(:plant)
+      create(:common_name, plant: plant, name: 'French Only', language: 'FR', primary: false)
+
+      expect(resolve_both_ways(plant, 'es')).to be_nil
+    end
+
+    it 'is locale-case-insensitive for the requested language' do
+      plant = create(:plant)
+      create(:common_name, plant: plant, name: 'Spanish Primary', language: 'ES', primary: true)
+
+      expect(resolve_both_ways(plant, 'es')).to eq 'Spanish Primary'
+      expect(resolve_both_ways(plant, 'ES')).to eq 'Spanish Primary'
+    end
+
+    it 'breaks ties within a tier by implicit id order identically on both paths' do
+      # Two EN primaries (a data anomaly the SQL .first tolerates): the record
+      # with the lower id wins, and both paths must agree on which one.
+      plant = create(:plant)
+      first = create(:common_name, plant: plant, name: 'EN Primary One', language: 'EN', primary: true)
+      second = create(:common_name, plant: plant, name: 'EN Primary Two', language: 'EN', primary: true)
+      winner = [first, second].min_by(&:id).name
+
+      expect(resolve_both_ways(plant, 'en')).to eq winner
+    end
+  end
 end

--- a/spec/models/policy_scope_loaded_drift_spec.rb
+++ b/spec/models/policy_scope_loaded_drift_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This spec exists so any future change to OwnedResourcePolicy::Scope forces the
+# same change in Types::PlantType#policy_scope_loaded. That method is an in-Ruby
+# transcription of OwnedResourcePolicy::Scope#resolve used on the eager-loaded
+# varieties path; if the two ever drift, the loaded list would return a
+# different visible set than the SQL policy scope. These parameterized examples
+# call the REAL Types::PlantType#policy_scope_loaded and assert its id-set
+# EXACTLY equals OwnedResourcePolicy::Scope.new(user, plant.varieties).resolve's
+# id-set for every trust tier, so a change to one without the other fails here.
+RSpec.describe 'policy_scope_loaded drift guard', type: :model do
+  let(:owner_email) { 'owner@example.com' }
+  let(:other_email) { 'other@example.com' }
+
+  # A real PlantType instance whose public policy_scope_loaded we exercise
+  # directly (object/context are unused by that method). graphql-ruby marks
+  # .new protected, so allocate the instance without running the type's
+  # authorization hooks.
+  let(:plant_type_instance) { Types::PlantType.allocate }
+
+  let(:plant) { create(:plant, :public) }
+
+  let!(:public_variety) do
+    create(:variety, :public, plant: plant, owned_by: other_email)
+  end
+  let!(:owned_private_variety) do
+    create(:variety, :private, plant: plant, owned_by: owner_email)
+  end
+  let!(:other_private_variety) do
+    create(:variety, :private, plant: plant, owned_by: other_email)
+  end
+
+  def loaded_ids(user)
+    plant_type_instance.policy_scope_loaded(user, plant.varieties.to_a).to_set(&:id)
+  end
+
+  def sql_ids(user)
+    OwnedResourcePolicy::Scope.new(user, plant.varieties).resolve.to_set(&:id)
+  end
+
+  {
+    'super-admin (trust 10)' => -> { build(:user, :superadmin, email: 'owner@example.com') },
+    'admin (trust 9)' => -> { build(:user, :admin, email: 'owner@example.com') },
+    'write-owner (trust 2)' => -> { build(:user, :readwrite, email: 'owner@example.com') },
+    'write-non-owner (trust 2)' => -> { build(:user, :readwrite, email: 'other@example.com') },
+    'read-only (trust 1)' => -> { build(:user, :readonly, email: 'owner@example.com') },
+    'nil user' => -> {}
+  }.each do |label, user_builder|
+    it "matches OwnedResourcePolicy::Scope for #{label}" do
+      user = instance_exec(&user_builder)
+
+      expect(loaded_ids(user)).to eq(sql_ids(user))
+    end
+  end
+end

--- a/spec/queries/plants_query_spec.rb
+++ b/spec/queries/plants_query_spec.rb
@@ -389,6 +389,23 @@ RSpec.describe 'Plants Query', type: :graphql_query do
 
       expect(plant_result.length).to eq 3
     end
+
+    # Regression: the name filter must not truncate the eager-loaded
+    # common_names association. When it matches only the FR name "Beta", the
+    # loaded-aware primary_common_name must still see the full association and
+    # return the EN primary "Alpha" (the unfiltered display value).
+    it 'does not truncate the loaded association used by primaryCommonName' do
+      plant = create(:plant, :public, scientific_name: 'silk tree')
+      create(:common_name, plant: plant, language: 'EN', primary: true, name: 'Alpha')
+      create(:common_name, plant: plant, language: 'FR', primary: true, name: 'Beta')
+
+      result = PlantApiSchema.execute(@query_string, variables: { name: 'Beta' })
+      nodes = result['data']['plants']['nodes']
+
+      expect(nodes.length).to eq 1
+      expect(nodes.first['scientificName']).to eq 'silk tree'
+      expect(nodes.first['primaryCommonName']).to eq 'Alpha'
+    end
   end
 
   describe 'anyName filter' do
@@ -458,6 +475,23 @@ RSpec.describe 'Plants Query', type: :graphql_query do
       plant_result = result['data']['plants']['nodes']
 
       expect(plant_result.length).to eq 4
+    end
+
+    # Regression: the anyName filter must not truncate the eager-loaded
+    # common_names association. Matching only the FR name "Beta" must still
+    # leave the full association loaded so the loaded-aware
+    # primary_common_name returns the EN primary "Alpha" rather than nil.
+    it 'does not truncate the loaded association used by primaryCommonName' do
+      plant = create(:plant, :public, scientific_name: 'silk tree')
+      create(:common_name, plant: plant, language: 'EN', primary: true, name: 'Alpha')
+      create(:common_name, plant: plant, language: 'FR', primary: true, name: 'Beta')
+
+      result = PlantApiSchema.execute(@query_string, variables: { anyName: 'Beta' })
+      nodes = result['data']['plants']['nodes']
+
+      expect(nodes.length).to eq 1
+      expect(nodes.first['scientificName']).to eq 'silk tree'
+      expect(nodes.first['primaryCommonName']).to eq 'Alpha'
     end
   end
 


### PR DESCRIPTION
Benchmark-driven fix, replacing the originally planned trigram index (disproven: the ILIKE scan was 4ms all along — the cost was 949 unnecessary SQL round-trips).

**The problem** (reproduced on a production-snapshot benchmark DB): the mobile app's cache-priming query — `plants(language:"en") { nodes { … varieties { nodes {…} } } }`, unpaginated — issued **953 SQL queries**: up to 3 per plant from `Plant#primary_common_name`'s per-call fallback chain + 1 per plant for the nested varieties connection.

**The fix**: loaded-association-aware `primary_common_name` (byte-identical precedence, pinned by specs on both paths incl. tie-breaks), eager-loading in the list path with an in-memory mirror of the varieties policy scope, and EXISTS-subquery filter reshape.

**Results** (production data): FULL 953q/1,604ms → **3q/169ms** · PAGED 41q/56ms → **3q/8.3ms** · FILTERED ~173ms → **121ms**. Output digests byte-identical.

**Review war story**: the feared risk (duplicated authorization logic) was empirically cleared across a 6-tier × 421-combination matrix — and the review instead caught a real CRITICAL in the first cut: the `includes+references` truncation was corrupting `primaryCommonName` for **67 of 238** filtered results ("Okra"→nil). Fixed via EXISTS; regression specs proven to fail on the old code by transient revert; a drift-guard spec now forces `policy_scope_loaded` and `OwnedResourcePolicy::Scope` to change together (proven to bite under tampering).

Suite 1303/0; tripwires green; schema byte-identical. Backlog: Preloader/dataloader refactor to retire the auth-logic duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz