### PR TITLE
infra: production 1 vCPU (applied)

### DIFF
--- a/infra/envs/production/terraform.tfvars
+++ b/infra/envs/production/terraform.tfvars
@@ -6,11 +6,11 @@ aws_region     = "us-east-1"
 aws_account_id = "382724554857"
 
 # Image: updated by CI/CD pipeline on each deploy.
-image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:35c1bef18557"
+image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:d9115dc0d3bb"
 
 # ECS sizing (production: 2 tasks minimum)
-cpu           = 512
-memory        = 1024
+cpu           = 1024
+memory        = 2048
 desired_count = 2
 min_capacity  = 2
 max_capacity  = 6


### PR DESCRIPTION
Already applied + deployed (service revision :5, stable, verified ~0.3-0.7s on the mobile cache query vs 2.5-3.6s before the perf fix + bump). Fargate requires 2GB memory at 1 vCPU. +~$30/mo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz