### PR TITLE
deps: puma 8.0.2 - clears the last two security alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 8.1.3'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.6.3'
 # Use Puma as the app server
-gem 'puma', '~> 6.6'
+gem 'puma', '~> 8.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    puma (6.6.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -333,7 +333,7 @@ DEPENDENCIES
   mobility (~> 1.2.9)
   paper_trail (~> 17.0)
   pg (~> 1.6.3)
-  puma (~> 6.6)
+  puma (~> 8.0)
   pundit (~> 2.5)
   pundit-matchers
   rack-cors (~> 2.0.2)


### PR DESCRIPTION
puma 6.6.1 → 8.0.2 (`--conservative`; 4-line lock delta). Clears both remaining Dependabot alerts (PROXY-protocol CVEs fixed in 7.2.1) — repo goes from 121 findings at project start to **zero**. config/puma.rb unchanged (all directives verified on 8.0.2). Boot-verified single/cluster/production-image. Reviewed (spec ✅ / quality approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRr9uSixH1G6P2bhf5xUz