### PR TITLE
fix(backfill): dry-run projects personal-org count instead of 0

### DIFF
--- a/app/services/ownership_backfill.rb
+++ b/app/services/ownership_backfill.rb
@@ -232,10 +232,12 @@ class OwnershipBackfill
       cache[email] = principal
     end
 
-    # Create personal orgs for all HUMAN principals (not service)
+    # Create personal orgs for all HUMAN principals (not service). Dry-run
+    # stubs are NOT skipped here: create_personal_org_for! has a dry-run branch
+    # that counts (without writing) the personal orgs a real run would create,
+    # so the dry-run report projects the true count rather than 0.
     cache.each_value do |principal|
       next if principal.nil?
-      next if principal.respond_to?(:dry_run_stub?) && principal.dry_run_stub?
       next unless principal.kind == 'human'
 
       create_personal_org_for!(principal)

--- a/spec/services/ownership_backfill_spec.rb
+++ b/spec/services/ownership_backfill_spec.rb
@@ -191,6 +191,19 @@ RSpec.describe OwnershipBackfill, type: :service do
       svc.run
       expect(Principal.count).to eq initial_count
     end
+
+    it 'projects the personal-org count a real run would create (not 0)' do
+      # alice is a mapped human -> a real run creates 1 personal org for her.
+      # echo@echonet.org is a shared email -> service principal, no personal org.
+      # The dry-run must PROJECT this count so the review is trustworthy.
+      svc = run_backfill(
+        dry_run: true,
+        extra_users: [{ 'uid' => user_uid, 'email' => user_email, 'name' => 'Alice' }]
+      )
+      report = svc.run
+      expect(report.orgs_created_personal).to eq 1
+      expect(Organization.where(kind: 'personal').count).to eq 0 # still nothing written
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Found during a **local backfill rehearsal** before running against production. The `ownership:backfill` **dry-run** reported `Personal orgs created: 0` even when a real run would create N — one personal org per mapped/legacy human principal. Since the dry-run report is exactly what we review to decide whether to run the real backfill, a `0` here is dangerously misleading (it reads as "no personal orgs will be created").

Root cause: the personal-org loop skipped `DryRunStub` principals *before* calling `create_personal_org_for!`, which already has a dry-run branch that counts (without writing). The skip only affected dry-runs.

## Fix

Removed the pre-skip so dry-run stubs flow through `create_personal_org_for!`, which projects the count without writing. Real runs are unaffected (they never had stubs).

## Verification

- New spec: dry-run reports `orgs_created_personal == 1` for a mapped human while `Organization.where(kind: 'personal').count == 0` (nothing written).
- Local rehearsal: dry-run and real run now agree on the personal-org count.
- `ownership_backfill_spec.rb`: **42 examples, 0 failures**; rubocop clean.

Follow-up to #75. Merging deploys staging; production pauses for approval (this only needs to reach prod before the production dry-run is run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)