### PR TITLE
feat(ops): ownership backfill rake tasks, s3:// MAPPING support, and ops workflow

### DIFF
--- a/.github/workflows/ops-ownership-backfill.yml
+++ b/.github/workflows/ops-ownership-backfill.yml
@@ -1,0 +1,358 @@
+name: Ops - Ownership Backfill
+
+# ============================================================================
+# One-shot ops workflow: runs ownership:report, ownership:verify, or
+# ownership:backfill inside the deployed ECHO Plant API ECS container.
+#
+# PURPOSE
+# -------
+# This is the Stage S3 operator interface from the ownership-redesign rollout
+# (docs/ownership-redesign/rollout.md). It runs the three rake tasks in the
+# deployed ECS environment so the operator can review the dry-run report in
+# the GitHub Actions UI before committing to a live write.
+#
+# STANDARD OPERATING PROCEDURE
+#   1. Run action=report to see current fill status (no MAPPING/ECHO_ORG_ID needed).
+#   2. Run action=backfill, dry_run=TRUE to review the report (default -- safe).
+#   3. Review the task output in GITHUB_STEP_SUMMARY.
+#   4. For a live run: action=backfill, dry_run=FALSE, confirm_real_run=RUN-REAL-BACKFILL.
+#   5. Run action=verify to confirm invariants after the live backfill.
+#
+# NEVER TRIGGERS ITSELF -- only workflow_dispatch (manual).
+#
+# SAFETY GATE
+# -----------
+# If action=backfill AND dry_run=FALSE, the workflow FAILS immediately unless
+# confirm_real_run is the literal string "RUN-REAL-BACKFILL". This prevents
+# accidental live writes.
+#
+# IAM PREREQUISITES
+# -----------------
+# The plant-API ECS *task* role (plant-api-<env>-task-role) ALREADY grants
+# s3:GetObject/PutObject/ListBucket on the whole images bucket
+# (arn:aws:s3:::images-us-east-1.echocommunity.org and /*), per
+# infra/modules/plant-api/main.tf (data.aws_iam_policy_document.task_s3). So when
+# mapping_s3_uri points at that images bucket (the default the ECHOcommunity
+# export workflow writes to), THIS side needs NO IAM change.
+#
+# The only grant to apply lives on the ECHOcommunity side: letting the
+# ECHOcommunity export task WRITE the mapping into this bucket -- documented in
+# ECHOcommunity's ops-plant-identity-export.yml. If you point mapping_s3_uri at
+# a DIFFERENT bucket, grant this task role s3:GetObject on that bucket first.
+#
+# The report and verify tasks do NOT require a mapping file -- only backfill
+# needs the MAPPING env var.
+# ============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      action:
+        description: "Rake task to run (report=read-only stats, verify=invariant check, backfill=fill columns)"
+        required: true
+        type: choice
+        options:
+          - report
+          - verify
+          - backfill
+      dry_run:
+        description: "DRY_RUN=1 (default TRUE -- no DB writes). Set FALSE only with confirm_real_run."
+        required: true
+        type: boolean
+        default: true
+      mapping_s3_uri:
+        description: "S3 URI for the identity mapping file (required for backfill, e.g. s3://images-us-east-1.echocommunity.org/ownership-backfill/mapping.json)"
+        required: false
+        type: string
+        default: ""
+      echo_org_id:
+        description: "ECHO organization UUID from the IdP (required for backfill)"
+        required: false
+        type: string
+        default: ""
+      confirm_real_run:
+        description: "Type exactly 'RUN-REAL-BACKFILL' to allow a non-dry-run backfill. Leave empty for dry runs."
+        required: false
+        type: string
+        default: ""
+
+# Never run two ops tasks against the same environment at once.
+concurrency:
+  group: ops-ownership-backfill-${{ inputs.environment }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  # Log group name pattern: /ecs/plant-api-<env>
+  # Web task stream prefix: web  (container name: web)
+
+jobs:
+  safety-gate:
+    name: Safety gate check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if real backfill requested without confirmation
+        if: inputs.action == 'backfill' && inputs.dry_run == false
+        run: |
+          if [ "${{ inputs.confirm_real_run }}" != "RUN-REAL-BACKFILL" ]; then
+            echo "::error::SAFETY GATE: action=backfill with dry_run=FALSE requires"
+            echo "::error::  confirm_real_run to equal exactly 'RUN-REAL-BACKFILL'."
+            echo "::error::  Got: '${{ inputs.confirm_real_run }}'"
+            echo "::error::  Re-run the workflow and type RUN-REAL-BACKFILL in that field."
+            exit 1
+          fi
+          echo "Safety gate passed: confirm_real_run is 'RUN-REAL-BACKFILL'."
+
+      - name: Validate required inputs for backfill
+        if: inputs.action == 'backfill'
+        run: |
+          if [ -z "${{ inputs.mapping_s3_uri }}" ]; then
+            echo "::error::action=backfill requires mapping_s3_uri."
+            exit 1
+          fi
+          if [ -z "${{ inputs.echo_org_id }}" ]; then
+            echo "::error::action=backfill requires echo_org_id."
+            exit 1
+          fi
+
+  run-task:
+    name: Run ownership:${{ inputs.action }} (${{ inputs.environment }})
+    needs: safety-gate
+    runs-on: ubuntu-latest
+
+    # Scope the OIDC role to the chosen environment. Required-reviewer gate for
+    # production is configured in repo Settings -> Environments.
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+        env:
+          DEPLOY_ROLE_ARN: arn:aws:iam::382724554857:role/gha-plant-api-deploy
+
+      # ------------------------------------------------------------------
+      # Build the rake command from inputs.
+      # ------------------------------------------------------------------
+      - name: Build rake command
+        id: cmd
+        run: |
+          ACTION="${{ inputs.action }}"
+          DRY_RUN="${{ inputs.dry_run }}"
+          MAPPING="${{ inputs.mapping_s3_uri }}"
+          ECHO_ORG_ID="${{ inputs.echo_org_id }}"
+
+          case "$ACTION" in
+            report)
+              RAKE_CMD="bundle exec rake ownership:report"
+              ;;
+            verify)
+              RAKE_CMD="bundle exec rake ownership:verify"
+              ;;
+            backfill)
+              DR_FLAG="DRY_RUN=1"
+              if [ "$DRY_RUN" = "false" ]; then
+                DR_FLAG="DRY_RUN=0"
+              fi
+              RAKE_CMD="bundle exec rake ownership:backfill MAPPING=${MAPPING} ECHO_ORG_ID=${ECHO_ORG_ID} ${DR_FLAG}"
+              ;;
+          esac
+
+          echo "rake_cmd=${RAKE_CMD}" >> "$GITHUB_OUTPUT"
+          echo "Built rake command: ${RAKE_CMD}"
+
+      # ------------------------------------------------------------------
+      # Resolve environment-specific ECS names.
+      # ------------------------------------------------------------------
+      - name: Set ECS names
+        id: ecs
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            echo "cluster=plant-api-production"       >> "$GITHUB_OUTPUT"
+            echo "service=plant-api-production-web"   >> "$GITHUB_OUTPUT"
+            echo "taskdef=plant-api-production-web"   >> "$GITHUB_OUTPUT"
+            echo "container=web"                      >> "$GITHUB_OUTPUT"
+            echo "log_group=/ecs/plant-api-production" >> "$GITHUB_OUTPUT"
+          else
+            echo "cluster=plant-api-staging"          >> "$GITHUB_OUTPUT"
+            echo "service=plant-api-staging-web"      >> "$GITHUB_OUTPUT"
+            echo "taskdef=plant-api-staging-web"      >> "$GITHUB_OUTPUT"
+            echo "container=web"                      >> "$GITHUB_OUTPUT"
+            echo "log_group=/ecs/plant-api-staging"   >> "$GITHUB_OUTPUT"
+          fi
+
+      # ------------------------------------------------------------------
+      # Run the rake task via run-migration.sh (re-using the same pattern
+      # as the deploy workflow's migrate step). Capture the task ARN from
+      # stderr so we can fetch CloudWatch logs afterward.
+      # run-migration.sh prints "Task: <arn>" to stderr; we tee stderr to
+      # a file so the operator still sees it in the Actions log.
+      # ------------------------------------------------------------------
+      - name: Run rake task via ECS one-off task
+        id: run_task
+        run: |
+          CLUSTER="${{ steps.ecs.outputs.cluster }}"
+          SERVICE="${{ steps.ecs.outputs.service }}"
+          TASKDEF="${{ steps.ecs.outputs.taskdef }}"
+          CONTAINER="${{ steps.ecs.outputs.container }}"
+
+          # run-migration.sh is in the ECHOcommunity repo; for the plant-API we
+          # replicate the same one-off task pattern inline here.
+          REGION="${{ env.AWS_REGION }}"
+
+          # Build the container override.
+          RAKE_CMD="${{ steps.cmd.outputs.rake_cmd }}"
+          CMD_JSON="$(echo "$RAKE_CMD" | xargs printf '%s\n' | jq -R . | jq -cs .)"
+          OVERRIDES="$(jq -cn --arg name "$CONTAINER" --argjson cmd "$CMD_JSON" \
+            '{containerOverrides:[{name:$name, command:$cmd}]}')"
+
+          # Borrow the live service's awsvpc network config.
+          NETCFG="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \
+            --services "$SERVICE" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration' --output json)"
+
+          NETWORK="$(echo "$NETCFG" | jq -c '{awsvpcConfiguration:{
+            subnets: .subnets,
+            securityGroups: .securityGroups,
+            assignPublicIp: (.assignPublicIp // "DISABLED")
+          }}')"
+
+          echo "Starting one-off ECS task on ${CLUSTER}/${TASKDEF} ..."
+          TASK_ARN="$(aws ecs run-task --region "$REGION" --cluster "$CLUSTER" \
+            --task-definition "$TASKDEF" --launch-type FARGATE \
+            --network-configuration "$NETWORK" \
+            --overrides "$OVERRIDES" \
+            --started-by "gha-ops-backfill" \
+            --query 'tasks[0].taskArn' --output text)"
+
+          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
+            echo "::error::run-task returned no task ARN. Check IAM or capacity."
+            exit 1
+          fi
+          echo "Task ARN: $TASK_ARN"
+          echo "task_arn=${TASK_ARN}" >> "$GITHUB_OUTPUT"
+
+          # Extract short task ID for CloudWatch log stream name.
+          TASK_ID="${TASK_ARN##*/}"
+          echo "task_id=${TASK_ID}" >> "$GITHUB_OUTPUT"
+
+          echo "Waiting for task to stop ..."
+          aws ecs wait tasks-stopped --region "$REGION" --cluster "$CLUSTER" --tasks "$TASK_ARN"
+
+          EXIT_CODE="$(aws ecs describe-tasks --region "$REGION" --cluster "$CLUSTER" \
+            --tasks "$TASK_ARN" \
+            --query "tasks[0].containers[?name=='${CONTAINER}'].exitCode | [0]" \
+            --output text)"
+          REASON="$(aws ecs describe-tasks --region "$REGION" --cluster "$CLUSTER" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' --output text)"
+
+          echo "Container '${CONTAINER}' exitCode=${EXIT_CODE} stoppedReason=${REASON}"
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+          if [ -z "$EXIT_CODE" ] || [ "$EXIT_CODE" = "None" ]; then
+            echo "::error::No exit code -- the container likely never started."
+            echo "::error::Check CloudWatch log group ${{ steps.ecs.outputs.log_group }}"
+            exit 1
+          fi
+          exit "$EXIT_CODE"
+
+      # ------------------------------------------------------------------
+      # Fetch CloudWatch logs for the one-off task and echo them into
+      # $GITHUB_STEP_SUMMARY so the operator can review the rake output
+      # (report/dry-run report) without leaving the Actions UI.
+      #
+      # Log stream name: web/<container-name>/<short-task-id>
+      # ------------------------------------------------------------------
+      - name: Fetch CloudWatch task logs
+        if: always() && steps.run_task.outputs.task_id != ''
+        run: |
+          REGION="${{ env.AWS_REGION }}"
+          LOG_GROUP="${{ steps.ecs.outputs.log_group }}"
+          CONTAINER="${{ steps.ecs.outputs.container }}"
+          TASK_ID="${{ steps.run_task.outputs.task_id }}"
+          LOG_STREAM="${CONTAINER}/${CONTAINER}/${TASK_ID}"
+
+          echo "Fetching logs from ${LOG_GROUP}/${LOG_STREAM} ..."
+
+          # Wait up to 30s for the log stream to become available.
+          for i in $(seq 1 6); do
+            if aws logs describe-log-streams --region "$REGION" \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name-prefix "${CONTAINER}/${CONTAINER}/${TASK_ID}" \
+              --query 'logStreams[0].logStreamName' --output text 2>/dev/null | grep -q "${TASK_ID}"; then
+              break
+            fi
+            echo "  Log stream not yet available; waiting 5s (attempt ${i}/6) ..."
+            sleep 5
+          done
+
+          LOGS="$(aws logs get-log-events --region "$REGION" \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "$LOG_STREAM" \
+            --start-from-head \
+            --query 'events[*].message' \
+            --output text 2>/dev/null || echo '(log stream unavailable or empty)')"
+
+          echo "TASK_LOGS<<LOGS_EOF" >> "$GITHUB_ENV"
+          echo "$LOGS" >> "$GITHUB_ENV"
+          echo "LOGS_EOF" >> "$GITHUB_ENV"
+
+      - name: Write step summary
+        if: always()
+        run: |
+          {
+            echo "## Ownership Backfill -- \`ownership:${{ inputs.action }}\`"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Environment | \`${{ inputs.environment }}\` |"
+            echo "| Action | \`ownership:${{ inputs.action }}\` |"
+            if [ "${{ inputs.action }}" = "backfill" ]; then
+              if [ "${{ inputs.dry_run }}" = "true" ]; then
+                echo "| DRY_RUN | \`1\` (no DB writes) |"
+              else
+                echo "| DRY_RUN | \`0\` (DATA WRITTEN) |"
+              fi
+              echo "| MAPPING | \`${{ inputs.mapping_s3_uri }}\` |"
+              echo "| ECHO_ORG_ID | \`${{ inputs.echo_org_id }}\` |"
+            fi
+            echo "| Task ARN | \`${{ steps.run_task.outputs.task_arn }}\` |"
+            echo "| Exit code | \`${{ steps.run_task.outputs.exit_code }}\` |"
+            echo ""
+            if [ "${{ steps.run_task.outputs.exit_code }}" = "0" ]; then
+              echo "**Status: SUCCEEDED**"
+            else
+              echo "**Status: FAILED** (exit code \`${{ steps.run_task.outputs.exit_code }}\`)"
+            fi
+            echo ""
+            echo "### Task output (CloudWatch logs)"
+            echo '```'
+            echo "$TASK_LOGS"
+            echo '```'
+            echo ""
+            echo "### How to view full logs"
+            echo ""
+            echo "If log output is truncated, open CloudWatch Logs directly:"
+            echo ""
+            echo '```'
+            echo "aws logs tail ${{ steps.ecs.outputs.log_group }} --follow \\"
+            echo "  --log-stream-names ${{ steps.ecs.outputs.container }}/${{ steps.ecs.outputs.container }}/${{ steps.run_task.outputs.task_id }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/lib/tasks/ownership.rake
+++ b/lib/tasks/ownership.rake
@@ -3,12 +3,40 @@
 # Ownership backfill, verify, and report rake tasks for the Phase B
 # ownership-redesign rollout (Stage S3).
 #
+# MAPPING env var accepts either a local filesystem path OR an s3:// URI.
+# When an s3:// URI is supplied the object is downloaded to a Tempfile before
+# being passed to OwnershipBackfill. The ECS task role needs s3:GetObject on
+# that URI (see .github/workflows/ops-ownership-backfill.yml prerequisites).
+#
 # Usage:
-#   rake ownership:backfill MAPPING=<path> ECHO_ORG_ID=<uuid>
+#   rake ownership:backfill MAPPING=<path-or-s3-uri> ECHO_ORG_ID=<uuid>
 #   rake ownership:backfill MAPPING=<path> ECHO_ORG_ID=<uuid> DRY_RUN=0
 #   rake ownership:backfill MAPPING=<path> ECHO_ORG_ID=<uuid> DRY_RUN=0 BATCH_SIZE=200
 #   rake ownership:verify
 #   rake ownership:report
+
+# Downloads a mapping JSON from S3 and yields the local tempfile path.
+# Used by ownership:backfill when MAPPING is an s3:// URI.
+# The tempfile is deleted after the block returns.
+def with_mapping_path(mapping_env)
+  if mapping_env.start_with?('s3://')
+    uri_path = mapping_env.sub(%r{\As3://}, '')
+    bucket, *key_parts = uri_path.split('/')
+    key = key_parts.join('/')
+    puts "  Downloading mapping from s3://#{bucket}/#{key} ..."
+    s3 = Aws::S3::Client.new
+    tmp = Tempfile.new(['ownership_mapping', '.json'])
+    begin
+      s3.get_object(bucket: bucket, key: key, response_target: tmp.path)
+      yield tmp.path
+    ensure
+      tmp.close
+      tmp.unlink
+    end
+  else
+    yield mapping_env
+  end
+end
 
 namespace :ownership do
   # ---------------------------------------------------------------------------
@@ -20,8 +48,8 @@ namespace :ownership do
     and defaults to DRY_RUN=1 -- no writes unless DRY_RUN=0.
 
     Required env vars:
-      MAPPING      Path to IdP export JSON { users:[{uid,email,name}...],
-                   organizations:[{id,name,slug}...] }
+      MAPPING      Local path OR s3:// URI to IdP export JSON
+                   { users:[{uid,email,name}...], organizations:[{id,name,slug}...] }
       ECHO_ORG_ID  IdP UUID of the ECHO organization (must be in mapping)
 
     Optional env vars:
@@ -29,30 +57,32 @@ namespace :ownership do
       BATCH_SIZE   Records per transaction batch (default 500)
   DESC
   task backfill: :environment do
-    mapping_path = ENV.fetch('MAPPING', nil)
+    mapping_env  = ENV.fetch('MAPPING', nil)
     echo_org_id  = ENV.fetch('ECHO_ORG_ID', nil)
     dry_run      = ENV.fetch('DRY_RUN', '1') != '0'
     batch_size   = ENV.fetch('BATCH_SIZE', '500').to_i
 
-    abort 'ERROR: MAPPING env var is required' if mapping_path.blank?
+    abort 'ERROR: MAPPING env var is required' if mapping_env.blank?
     abort 'ERROR: ECHO_ORG_ID env var is required' if echo_org_id.blank?
 
     puts 'ownership:backfill starting'
     puts "  DRY_RUN=#{dry_run ? '1 (no writes)' : '0 (WRITING)'}"
-    puts "  MAPPING=#{mapping_path}"
+    puts "  MAPPING=#{mapping_env}"
     puts "  ECHO_ORG_ID=#{echo_org_id}"
     puts "  BATCH_SIZE=#{batch_size}"
     puts
 
-    backfill = OwnershipBackfill.new(
-      mapping_path: mapping_path,
-      echo_org_id: echo_org_id,
-      dry_run: dry_run,
-      batch_size: batch_size
-    )
+    with_mapping_path(mapping_env) do |mapping_path|
+      backfill = OwnershipBackfill.new(
+        mapping_path: mapping_path,
+        echo_org_id: echo_org_id,
+        dry_run: dry_run,
+        batch_size: batch_size
+      )
 
-    report = backfill.run
-    puts report
+      report = backfill.run
+      puts report
+    end
   rescue ArgumentError => e
     abort "ERROR: #{e.message}"
   end

--- a/spec/tasks/ownership_rake_spec.rb
+++ b/spec/tasks/ownership_rake_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# Load the top-level with_mapping_path helper defined in ownership.rake.
+# We load it via the task namespace (rails loads all lib/tasks/**/*.rake
+# when the :environment task prerequisite runs), but for unit isolation
+# we load it explicitly here.
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe 'with_mapping_path (ownership.rake helper)' do
+  # Build a minimal valid mapping JSON body.
+  def valid_mapping_json
+    echo_id = SecureRandom.uuid
+    {
+      'generated_at' => Time.current.iso8601,
+      'users' => [{ 'uid' => SecureRandom.uuid, 'email' => 'a@example.com', 'name' => 'A' }],
+      'organizations' => [{ 'id' => echo_id, 'name' => 'ECHO', 'slug' => 'echo' }]
+    }.to_json
+  end
+
+  context 'when MAPPING is a local filesystem path' do
+    it 'yields the path unchanged and does not call Aws::S3::Client' do
+      allow(Aws::S3::Client).to receive(:new)
+
+      Tempfile.create(['mapping', '.json']) do |f|
+        f.write(valid_mapping_json)
+        f.flush
+        yielded = nil
+        with_mapping_path(f.path) { |p| yielded = p }
+        expect(yielded).to eq(f.path)
+      end
+
+      expect(Aws::S3::Client).not_to have_received(:new)
+    end
+  end
+
+  context 'when MAPPING is an s3:// URI' do
+    let(:s3_uri) { 's3://my-images-bucket/ownership-backfill/mapping.json' }
+    let(:fake_s3) { instance_double(Aws::S3::Client) }
+    let(:json_body) { valid_mapping_json }
+
+    before do
+      allow(Aws::S3::Client).to receive(:new).and_return(fake_s3)
+      allow(fake_s3).to receive(:get_object) do |args|
+        # Simulate writing the JSON to the response_target path.
+        File.write(args[:response_target], json_body)
+      end
+    end
+
+    it 'calls get_object with the correct bucket and key' do
+      with_mapping_path(s3_uri) { |_p| nil }
+
+      expect(fake_s3).to have_received(:get_object).with(
+        hash_including(bucket: 'my-images-bucket', key: 'ownership-backfill/mapping.json')
+      )
+    end
+
+    it 'yields a local path whose content matches the downloaded JSON' do
+      yielded_content = nil
+      with_mapping_path(s3_uri) { |p| yielded_content = File.read(p) }
+      expect(yielded_content).to eq(json_body)
+    end
+
+    it 'deletes the tempfile after the block returns' do
+      captured_path = nil
+      with_mapping_path(s3_uri) { |p| captured_path = p }
+      expect(File).not_to exist(captured_path)
+    end
+
+    it 'deletes the tempfile even when the block raises' do
+      captured_path = nil
+      begin
+        with_mapping_path(s3_uri) do |p|
+          captured_path = p
+          raise 'intentional error'
+        end
+      rescue RuntimeError
+        nil
+      end
+      expect(File).not_to exist(captured_path)
+    end
+
+    it 'handles keys with multiple path segments' do
+      uri = 's3://bucket/deep/nested/path/mapping.json'
+      allow(Aws::S3::Client).to receive(:new).and_return(fake_s3)
+      allow(fake_s3).to receive(:get_object) { |args| File.write(args[:response_target], '{}') }
+
+      with_mapping_path(uri) { |_p| nil }
+
+      expect(fake_s3).to have_received(:get_object).with(
+        hash_including(bucket: 'bucket', key: 'deep/nested/path/mapping.json')
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What this adds

A manual (`workflow_dispatch`) ops runner — `.github/workflows/ops-ownership-backfill.yml` — to run `ownership:report` / `ownership:verify` / `ownership:backfill` inside the deployed plant-API ECS environment (Stage S3 of the ownership rollout), so the operator reviews the dry-run report in the Actions run summary before any live write. Also extends `ownership.rake` so `MAPPING` accepts an `s3://` URI (downloads to a tempfile).

## Safety

- **DRY_RUN is the default.** A real backfill (`action=backfill`, `dry_run=false`) is hard-gated: the workflow fails unless `confirm_real_run == RUN-REAL-BACKFILL`.
- Production runs are additionally gated by the `production` GitHub environment reviewer approval.
- The one-off task's CloudWatch logs are echoed into the run summary for review.

## AWS names — verified (not guessed)

Confirmed against `.github/workflows/deploy.yml` and `infra/modules/plant-api/main.tf`: cluster/service/taskdef `plant-api-<env>-web`, container `web`, log stream `web/web/<task-id>`, OIDC role `gha-plant-api-deploy`.

## IAM

**This (plant-API) side needs NO IAM change** — the plant-api ECS *task* role already has bucket-wide `s3:GetObject` on `images-us-east-1.echocommunity.org` (per `data.aws_iam_policy_document.task_s3`). The only grant to apply is on the ECHOcommunity export side (see ECHOInternational/ECHOcommunity#229).

## Note on the rebuild

The original branch was accidentally cut from a **stale master** and its diff re-introduced `ownership_backfill.rb`/`ownership_backfill_spec.rb`/`.rubocop.yml` — which would have **reverted the #76 dry-run fix**. Rebuilt off current master; this PR now touches only the workflow, `ownership.rake`, and the new rake spec. `ownership_rake_spec.rb`: 6 examples, 0 failures; rubocop clean.

Does not merge or trigger anything on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)