### PR TITLE
infra(S6): divergence logging + activate log_only in production

### DIFF
--- a/infra/envs/production/main.tf
+++ b/infra/envs/production/main.tf
@@ -28,6 +28,9 @@ module "plant_api" {
   aws_region     = var.aws_region
   aws_account_id = var.aws_account_id
 
+  # Rollout stage S6 divergence logging ("log_only" to enable; empty = off).
+  org_authz_cutover = var.org_authz_cutover
+
   # Container image (updated by CI/CD pipeline)
   image = var.image
 

--- a/infra/envs/production/terraform.tfvars
+++ b/infra/envs/production/terraform.tfvars
@@ -5,8 +5,18 @@
 aws_region     = "us-east-1"
 aws_account_id = "382724554857"
 
-# Image: updated by CI/CD pipeline on each deploy.
-image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:d9115dc0d3bb"
+# Image: the live service image is managed by the CI deploy script
+# (.github/scripts/deploy-ecs.sh registers ECS task-def revisions directly and
+# does NOT write back here), so this pin is only the value Terraform bakes into
+# the revisions it registers. It is kept in sync with the live image so that a
+# Terraform-registered revision is never a rollback hazard. Live prod as of
+# 2026-07-14 = e4997021317e (plant-api-production-web:10).
+image = "382724554857.dkr.ecr.us-east-1.amazonaws.com/plant-api:e4997021317e"
+
+# Rollout stage S6 — divergence-logging toggle. "log_only" injects
+# ORG_AUTHZ_CUTOVER=log_only so OwnedResourcePolicy emits authz.legacy_divergence
+# events (observation only; enforcement is unchanged). Set back to "" for S7.
+org_authz_cutover = "log_only"
 
 # ECS sizing (production: 2 tasks minimum)
 cpu           = 1024

--- a/infra/envs/production/variables.tf
+++ b/infra/envs/production/variables.tf
@@ -109,3 +109,9 @@ variable "route53_record_enabled" {
   type    = bool
   default = false
 }
+
+variable "org_authz_cutover" {
+  description = "S6 divergence logging toggle for production (\"log_only\" to enable)."
+  type        = string
+  default     = ""
+}

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -28,6 +28,9 @@ module "plant_api" {
   aws_region     = var.aws_region
   aws_account_id = var.aws_account_id
 
+  # Rollout stage S6 divergence logging ("log_only" to enable; empty = off).
+  org_authz_cutover = var.org_authz_cutover
+
   # Container image (updated by CI/CD pipeline)
   image = var.image
 

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -129,3 +129,9 @@ variable "alb_zone_id" {
   type    = string
   default = ""
 }
+
+variable "org_authz_cutover" {
+  description = "S6 divergence logging toggle for staging (\"log_only\" to enable)."
+  type        = string
+  default     = ""
+}

--- a/infra/modules/plant-api/main.tf
+++ b/infra/modules/plant-api/main.tf
@@ -32,7 +32,15 @@ locals {
     { name = "DATABASE_PORT", value = tostring(var.database_port) },
   ]
 
-  container_environment = local.base_env
+  # Rollout stage S6: divergence-logging toggle. When org_authz_cutover is set
+  # (e.g. "log_only"), inject ORG_AUTHZ_CUTOVER so OwnedResourcePolicy emits
+  # authz.legacy_divergence events. Omitted from the env entirely when empty so
+  # the flag is fully off by default.
+  cutover_env = var.org_authz_cutover != "" ? [
+    { name = "ORG_AUTHZ_CUTOVER", value = var.org_authz_cutover },
+  ] : []
+
+  container_environment = concat(local.base_env, local.cutover_env)
 
   # -------------------------------------------------------------------------
   # Secrets Manager ARNs for the task secrets block.

--- a/infra/modules/plant-api/variables.tf
+++ b/infra/modules/plant-api/variables.tf
@@ -225,3 +225,9 @@ variable "alb_zone_id" {
   type        = string
   default     = ""
 }
+
+variable "org_authz_cutover" {
+  description = "Rollout stage S6 divergence logging. Set to \"log_only\" to emit authz.legacy_divergence events (observation only, no enforcement change). Empty (default) leaves the flag unset/off."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## What & why (rollout stage S6)

Turns on **cutover observation** for the ownership redesign. When `ORG_AUTHZ_CUTOVER=log_only`, `OwnedResourcePolicy#log_legacy_divergence` emits a structured `authz.legacy_divergence` event whenever access is granted **only** by a legacy branch (email ownership / trust-9 override) and would be denied once legacy authz is removed. **No enforcement change** — decisions are identical; this is pure observation. A soak window with **zero** such events is the evidence gate for S7. (The logging code itself already shipped with S2/S4.)

## Changes

1. **Terraform plumbing** — new `org_authz_cutover` variable threaded module → staging/production. Empty (default) omits the env var entirely, so the flag is fully off unless set.
2. **Production activation** — `infra/envs/production/terraform.tfvars` sets `org_authz_cutover = "log_only"` and bumps the image pin `d9115dc0d3bb → e4997021317e` (the live `plant-api-production-web:10`). CI manages the live image out-of-band via `deploy-ecs.sh` and never writes back to tfvars, so this pin only governs the revision Terraform registers; syncing it means activating via the family's latest revision can't roll the image back.

## Safety — verified by read-only `terraform plan`

- `aws_ecs_task_definition.web` / `.migrate` → replaced to add `ORG_AUTHZ_CUTOVER=log_only` (+ image sync).
- `aws_ecs_service.web` → **not in the plan**; `ignore_changes = [task_definition]` means `apply` registers the env-var revision but does **not** repoint the running service. No image rollback, no runtime change until a deploy carries the env var forward.
- `Plan: 2 to add, 0 to change, 2 to destroy` (the two task-def replacements).

## Activation runbook (after merge)

1. `git pull` master; `cd infra/envs/production && terraform init && terraform plan` (confirm the two task-def replacements + service untouched), then `terraform apply`.
2. Repoint the service onto the new (env-var-bearing) revision — either a normal `deploy.yml` run, or the minimal:
   `aws ecs update-service --cluster plant-api-production --service plant-api-production-web --task-definition plant-api-production-web --force-new-deployment`
3. Verify `ORG_AUTHZ_CUTOVER=log_only` on the running task and watch CloudWatch for `authz.legacy_divergence`. Zero over the agreed window = S7 gate. To turn off: set `org_authz_cutover = ""` and re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)