### PR TITLE
feat(authz): restrict all category writes to system superusers

### DIFF
--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -1,5 +1,36 @@
 # frozen_string_literal: true
 
-# Defines the unique secuirty policy for Category objects
+# Security policy for Category objects.
+#
+# Categories are a small, curated taxonomy that the mobile app's top-down
+# navigation depends on, so they are treated like the other controlled lookup
+# tables (Tolerance, GrowthHabit, Antinutrient, ImageAttribute): every write is
+# restricted to system superusers (plant trust >= 10). This prevents ordinary
+# writers from forking the shared taxonomy with near-duplicate categories.
+#
+# Reads are intentionally left to OwnedResourcePolicy so public categories stay
+# readable by everyone, including anonymous clients. Associating a record WITH
+# a category is authorized against the owning record's :update? in
+# Mutations::Relations::UpdateRelationsBaseMutation, not here, so contributors
+# can still categorize their plants.
 class CategoryPolicy < OwnedResourcePolicy
+  def create?
+    user&.super_admin?
+  end
+
+  def update?
+    create?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def soft_delete?
+    create?
+  end
+
+  def restore?
+    create?
+  end
 end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -10,7 +10,12 @@ FactoryBot.define do
     attribution { Faker::Lorem.paragraph }
     s3_bucket { 'images-us-east-1.echocommunity.org' }
     sequence('s3_key') { |n| "image#{n}.jpg" }
-    imageable { create(:category) }
+    # A plant is the representative parent: an ordinary owned record whose
+    # :update? follows the normal ownership rules. Do NOT use a category here --
+    # CategoryPolicy restricts every write to superusers, and ImagePolicy
+    # delegates to the imageable's :update?, so a category parent would silently
+    # make these specs assert category gating rather than image inheritance.
+    imageable { create(:plant) }
     trait :public do
       visibility { :public }
     end

--- a/spec/mutations/create_category_spec.rb
+++ b/spec/mutations/create_category_spec.rb
@@ -73,8 +73,31 @@ RSpec.describe 'Create Category Mutation', type: :graphql_mutation do
     end
   end
 
-  context 'when user is authenticated' do
+  # Categories are a curated taxonomy: ordinary writers may categorize their own
+  # records but may not add to the taxonomy itself (see CategoryPolicy).
+  context 'when user has ordinary write access' do
     let(:current_user) { build(:user, :readwrite) }
+    it 'returns a forbidden error' do
+      result = PlantApiSchema.execute(
+        query_string,
+        context: { current_user: current_user },
+        variables: {
+          input: {
+            name: 'newly created record',
+            description: 'with an attached description',
+            language: 'en'
+          }
+        }
+      )
+      expect(result['data']).to be_nil
+      expect(result['errors']).to_not be_nil
+      expect(result['errors'].count).to eq 1
+      expect(result['errors'][0]['extensions']['code']).to eq 403
+    end
+  end
+
+  context 'when user is a superadmin' do
+    let(:current_user) { build(:user, :superadmin) }
     before :each do
       @result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                          input: {
@@ -109,7 +132,7 @@ RSpec.describe 'Create Category Mutation', type: :graphql_mutation do
     end
   end
   describe 'parameters' do
-    let(:current_user) { build(:user, :readwrite) }
+    let(:current_user) { build(:user, :superadmin) }
     describe 'language' do
       it 'sets the language' do
         es_result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {

--- a/spec/mutations/create_image_spec.rb
+++ b/spec/mutations/create_image_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
 
   context 'when user is not authenticated' do
     let(:current_user) { nil }
-    let(:imageable) { create(:category) }
+    let(:imageable) { create(:plant) }
     it 'returns an error when called' do
-      imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+      imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
 
       result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                         input: {
@@ -63,9 +63,9 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
 
   context 'when user is read only' do
     let(:current_user) { build(:user, :readonly) }
-    let(:imageable) { create(:category) }
+    let(:imageable) { create(:plant) }
     it 'returns an error when called' do
-      imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+      imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
       result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                         input: {
                                           imageId: 'da5818be-da49-428f-87e6-e944dbb502f9',
@@ -86,9 +86,9 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
 
   context 'when user is authenticated' do
     let(:current_user) { build(:user, :readwrite) }
-    let(:imageable) { create(:category, owned_by: current_user.email) }
+    let(:imageable) { create(:plant, owned_by: current_user.email) }
     before :each do
-      imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+      imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
       @result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                          input: {
                                            imageId: 'da5818be-da49-428f-87e6-e944dbb502f9',
@@ -127,11 +127,11 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
   end
   describe 'parameters' do
     let(:current_user) { build(:user, :readwrite) }
-    let(:imageable) { create(:category, owned_by: current_user.email) }
+    let(:imageable) { create(:plant, owned_by: current_user.email) }
 
     describe 'image_attributes' do
       it 'adds an array of provided attributes' do
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         attr_a = create(:image_attribute)
         attr_b = create(:image_attribute)
         attr_a_id = PlantApiSchema.id_from_object(attr_a, ImageAttribute, {})
@@ -156,7 +156,7 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
         expect(created_image.image_attributes).to include attr_b
       end
       it "succeeds with included errors when the provided attribute doesn't exist" do
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         attr_a = create(:image_attribute)
         attr_a_id = PlantApiSchema.id_from_object(attr_a, ImageAttribute, {})
         attr_b_id = "#{attr_a_id[0...-4]}fake"
@@ -190,7 +190,7 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
 
     describe 'language' do
       it 'sets the language' do
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         es_result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                              input: {
                                                imageId: 'da5818be-da49-428f-87e6-e944dbb502f9',
@@ -211,7 +211,7 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
     end
     describe 'visibility' do
       it 'sets the visibility' do
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                           input: {
                                             name: 'a public record',
@@ -231,7 +231,7 @@ RSpec.describe 'Create Image Mutation', type: :graphql_mutation do
       end
 
       it 'exposes visibility as PRIVATE by default' do
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                           input: {
                                             name: 'a private record',

--- a/spec/mutations/delete_category_spec.rb
+++ b/spec/mutations/delete_category_spec.rb
@@ -72,24 +72,49 @@ RSpec.describe 'Delete Category Mutation', type: :graphql_mutation do
         expect(result['errors'][0]['extensions']['code']).to eq 403
       end
     end
+    # Categories are a curated taxonomy: deleting one is superuser-only, so
+    # owning a category no longer confers the right to delete it.
     context 'when user owns the record' do
       before :each do
         @category_id = PlantApiSchema.id_from_object(category, Category, {})
       end
-      it 'deletes the record' do
+      it 'still raises a forbidden error and leaves the record in place' do
         record_id = category.id
-        expect { Category.find record_id }.to_not raise_error(ActiveRecord::RecordNotFound)
         result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                           input: {
                                             categoryId: @category_id
                                           }
                                         })
-        expect(result).to_not include 'errors'
-        expect(result).to include 'data'
-        expect(result['data']['deleteCategory']).to include 'categoryId'
-        expect(result['data']['deleteCategory']['categoryId']).to eq @category_id
-        expect { Category.find record_id }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(result['data']).to be_nil
+        expect(result['errors']).to_not be_nil
+        expect(result['errors'].count).to eq 1
+        expect(result['errors'][0]['extensions']['code']).to eq 403
+        expect { Category.find record_id }.to_not raise_error
       end
+    end
+  end
+
+  context 'when user is a superadmin' do
+    let(:current_user) { build(:user, :superadmin) }
+    let(:category) {
+      create(:category, owned_by: 'someone@else.com', created_by: 'someone@else.com', name: 'a name',
+                        description: 'a description')
+    }
+
+    it 'deletes the record' do
+      category_id = PlantApiSchema.id_from_object(category, Category, {})
+      record_id = category.id
+      expect { Category.find record_id }.to_not raise_error
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          categoryId: category_id
+                                        }
+                                      })
+      expect(result).to_not include 'errors'
+      expect(result).to include 'data'
+      expect(result['data']['deleteCategory']).to include 'categoryId'
+      expect(result['data']['deleteCategory']['categoryId']).to eq category_id
+      expect { Category.find record_id }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/mutations/mutation_error_spec.rb
+++ b/spec/mutations/mutation_error_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Mutation Error' do
     context 'when a record fails persistence' do
       let(:current_user) { build(:user) }
       let(:existing_record) { create(:image, owned_by: current_user.email) }
-      let(:imageable) { create(:category, owned_by: current_user.email) }
+      let(:imageable) { create(:plant, owned_by: current_user.email) }
       let(:query_string) {
         <<-GRAPHQL
         mutation($input: CreateImageInput!){
@@ -97,7 +97,7 @@ RSpec.describe 'Mutation Error' do
       }
       before :each do
         image_id = existing_record.id
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         @result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                            input: {
                                              imageId: image_id,
@@ -134,7 +134,7 @@ RSpec.describe 'Mutation Error' do
     context 'when there are multiple errors' do
       let(:current_user) { build(:user) }
       let(:existing_record) { create(:image, owned_by: current_user.email) }
-      let(:imageable) { create(:category, owned_by: current_user.email) }
+      let(:imageable) { create(:plant, owned_by: current_user.email) }
       let(:query_string) {
         <<-GRAPHQL
         mutation($input: CreateImageInput!){
@@ -160,7 +160,7 @@ RSpec.describe 'Mutation Error' do
       }
       before :each do
         image_id = existing_record.id
-        imageable_id = PlantApiSchema.id_from_object(imageable, Category, {})
+        imageable_id = PlantApiSchema.id_from_object(imageable, Plant, {})
         attr_a = create(:image_attribute)
         attr_a_id = PlantApiSchema.id_from_object(attr_a, ImageAttribute, {})
         @attr_b_id = "#{attr_a_id[0...-4]}fake"

--- a/spec/mutations/update_category_spec.rb
+++ b/spec/mutations/update_category_spec.rb
@@ -70,12 +70,20 @@ RSpec.describe 'Update Category Mutation', type: :graphql_mutation do
     end
   end
 
-  context 'when user is not an admin' do
+  # Categories are a curated taxonomy (CategoryPolicy restricts every write to
+  # superusers), so ordinary write access is forbidden even for a category the
+  # user owns. Owning a category no longer confers the right to edit it.
+  context 'when user has ordinary write access' do
     let(:current_user) { build(:user, :readwrite) }
-    let(:category) { create(:category, owned_by: current_user.email, created_by: current_user.email, name: 'a name', description: 'a description') }
+    let(:category) {
+      create(:category, owned_by: current_user.email, created_by: current_user.email, name: 'a name',
+                        description: 'a description')
+    }
 
     context 'when the user does not own the record' do
-      let(:category) { create(:category, owned_by: 'notme', created_by: 'notme', name: 'a name', description: 'a description') }
+      let(:category) {
+        create(:category, owned_by: 'notme', created_by: 'notme', name: 'a name', description: 'a description')
+      }
       it 'raises an error' do
         @category_id = PlantApiSchema.id_from_object(category, Category, {})
         result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
@@ -92,75 +100,101 @@ RSpec.describe 'Update Category Mutation', type: :graphql_mutation do
         expect(result['errors'][0]['extensions']['code']).to eq 403
       end
     end
+
     context 'when user owns the record' do
-      before :each do
+      it 'still raises a forbidden error' do
         @category_id = PlantApiSchema.id_from_object(category, Category, {})
-        @result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                          input: {
+                                            categoryId: @category_id,
+                                            name: 'updated record to this',
+                                            description: 'and updated the description',
+                                            language: 'en'
+                                          }
+                                        })
+        expect(result['data']).to be_nil
+        expect(result['errors']).to_not be_nil
+        expect(result['errors'].count).to eq 1
+        expect(result['errors'][0]['extensions']['code']).to eq 403
+      end
+    end
+  end
+
+  context 'when user is a superadmin' do
+    let(:current_user) { build(:user, :superadmin) }
+    let(:category) {
+      create(:category, owned_by: 'someone@else.com', created_by: 'someone@else.com', name: 'a name',
+                        description: 'a description')
+    }
+
+    before :each do
+      @category_id = PlantApiSchema.id_from_object(category, Category, {})
+      @result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                         input: {
+                                           categoryId: @category_id,
+                                           name: 'updated record to this',
+                                           description: 'and updated the description',
+                                           language: 'en'
+                                         }
+                                       })
+    end
+
+    it 'completes successfully' do
+      expect(@result).to_not include 'errors'
+      expect(@result).to include 'data'
+    end
+
+    it 'updates a record' do
+      category_result = @result['data']['updateCategory']['category']
+      expect(category_result['name']).to eq 'updated record to this'
+      expect(category_result['description']).to eq 'and updated the description'
+    end
+
+    it 'can update records in the speficied language' do
+      category_en_result = @result['data']['updateCategory']['category']
+      created_category_en = Category.find category_en_result['uuid']
+      expect(created_category_en.translations).to_not include 'es'
+      expect(created_category_en.translations).to include 'en'
+
+      es_result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
                                            input: {
                                              categoryId: @category_id,
-                                             name: 'updated record to this',
-                                             description: 'and updated the description',
-                                             language: 'en'
+                                             name: 'added this in spanish',
+                                             description: 'with an attached description in spanish',
+                                             language: 'es'
                                            }
                                          })
-      end
-      it 'completes successfully' do
-        expect(@result).to_not include 'errors'
-        expect(@result).to include 'data'
-      end
+      category_es_result = es_result['data']['updateCategory']['category']
+      created_category_es = Category.find category_es_result['uuid']
+      expect(created_category_es.translations).to include 'en'
+      expect(created_category_es.translations).to include 'es'
+    end
 
-      it 'updates a record' do
-        category_result = @result['data']['updateCategory']['category']
-        expect(category_result['name']).to eq 'updated record to this'
-        expect(category_result['description']).to eq 'and updated the description'
-      end
+    it 'can update the visibility status' do
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          categoryId: @category_id,
+                                          visibility: 'PUBLIC'
+                                        }
+                                      })
+      category_result = result['data']['updateCategory']['category']
+      created_category = Category.find category_result['uuid']
 
-      it 'can update records in the speficied language' do
-        category_en_result = @result['data']['updateCategory']['category']
-        created_category_en = Category.find category_en_result['uuid']
-        expect(created_category_en.translations).to_not include 'es'
-        expect(created_category_en.translations).to include 'en'
+      expect(created_category.visibility_public?).to be true
+      expect(created_category.visibility_private?).to be false
+    end
 
-        es_result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
-                                             input: {
-                                               categoryId: @category_id,
-                                               name: 'added this in spanish',
-                                               description: 'with an attached description in spanish',
-                                               language: 'es'
-                                             }
-                                           })
-        category_es_result = es_result['data']['updateCategory']['category']
-        created_category_es = Category.find category_es_result['uuid']
-        expect(created_category_es.translations).to include 'en'
-        expect(created_category_es.translations).to include 'es'
-      end
-
-      it 'can update the visibility status' do
-        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
-                                          input: {
-                                            categoryId: @category_id,
-                                            visibility: 'PUBLIC'
-                                          }
-                                        })
-        category_result = result['data']['updateCategory']['category']
-        created_category = Category.find category_result['uuid']
-
-        expect(created_category.visibility_public?).to be true
-        expect(created_category.visibility_private?).to be false
-      end
-
-      it 'returns errors when the input is invalid' do
-        result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
-                                          input: {
-                                            categoryId: @category_id,
-                                            name: nil
-                                          }
-                                        })
-        error_result = result['data']['updateCategory']['errors']
-        expect(error_result[0]['field']).to eq 'name'
-        expect(error_result[0]['message']).to eq "name can't be blank"
-        expect(error_result[0]['code']).to eq 400
-      end
+    it 'returns errors when the input is invalid' do
+      result = PlantApiSchema.execute(query_string, context: { current_user: current_user }, variables: {
+                                        input: {
+                                          categoryId: @category_id,
+                                          name: nil
+                                        }
+                                      })
+      error_result = result['data']['updateCategory']['errors']
+      expect(error_result[0]['field']).to eq 'name'
+      expect(error_result[0]['message']).to eq "name can't be blank"
+      expect(error_result[0]['code']).to eq 400
     end
   end
 end

--- a/spec/policies/category_policy_spec.rb
+++ b/spec/policies/category_policy_spec.rb
@@ -2,6 +2,16 @@
 
 require 'rails_helper'
 
+# Categories are a curated, globally-navigable taxonomy (the mobile app's
+# top-down navigation depends on them), so every WRITE action is restricted to
+# system superusers -- the same gate the other lookup-like policies use
+# (TolerancePolicy, GrowthHabitPolicy, AntinutrientPolicy, ImageAttributePolicy).
+#
+# READ behavior is deliberately unchanged: categories stay visible per the
+# ordinary owned-resource visibility/ownership rules so that public categories
+# remain readable by everyone, including anonymous clients. Associating records
+# WITH a category is governed by the owning record's own :update? (see
+# Mutations::Relations::UpdateRelationsBaseMutation), not by this policy.
 RSpec.describe CategoryPolicy, type: :policy do
   context 'when no user logged in' do
     let(:user) { nil }
@@ -13,15 +23,11 @@ RSpec.describe CategoryPolicy, type: :policy do
       before :each do
         @public_category = create(:category, :public)
         @private_category_not_owned = create(:category, :private)
-        # @private_category_owned = create(:category, :private, owned_by: user.id)
         @draft_category_not_owned = create(:category, :draft)
-        # @draft_category_owned = create(:category, :draft, owned_by: user.id)
         @deleted_category_not_owned = create(:category, :deleted)
-        # @deleted_category_owned = create(:category, :draft, owned_by: user.id)
       end
 
       it 'allows access to public records' do
-        # expect(scope.to_a).to include(records[:public_category])
         expect(scope.to_a).to include(@public_category)
       end
       it 'does not allow access to private records' do
@@ -155,11 +161,14 @@ RSpec.describe CategoryPolicy, type: :policy do
     end
   end
 
+  # A plain writer may create plants and specimens, but must NOT be able to add
+  # to or edit the shared category taxonomy -- that is the duplication risk this
+  # policy exists to prevent.
   context 'when user has write accesss' do
     let(:user) { build(:user, :readwrite) }
 
     let(:target) { Category }
-    it { is_expected.to permit_action(:create) }
+    it { is_expected.to forbid_action(:create) }
 
     context 'for public records' do
       let(:target) { build(:category, :public) }
@@ -177,8 +186,8 @@ RSpec.describe CategoryPolicy, type: :policy do
       context 'when owned by the user' do
         let(:target) { build(:category, :draft, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
     context 'for deleted records' do
@@ -191,8 +200,8 @@ RSpec.describe CategoryPolicy, type: :policy do
       context 'when owned by the user' do
         let(:target) { build(:category, :deleted, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
     context 'for private records' do
@@ -205,17 +214,19 @@ RSpec.describe CategoryPolicy, type: :policy do
       context 'when owned by the user' do
         let(:target) { build(:category, :private, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
   end
 
+  # Trust-9 admin keeps its broad READ scope, but category writes now require a
+  # system superuser (trust >= 10), same as the other curated lookup tables.
   context 'when user is admin' do
     let(:user) { build(:user, :admin) }
 
     let(:target) { Category }
-    it { is_expected.to permit_action(:create) }
+    it { is_expected.to forbid_action(:create) }
 
     describe 'scope' do
       before :each do
@@ -258,49 +269,49 @@ RSpec.describe CategoryPolicy, type: :policy do
     context 'for public records' do
       let(:target) { build(:category, :public) }
       it { is_expected.to permit_action(:show) }
-      it { is_expected.to permit_action(:update) }
+      it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
     end
     context 'for draft records' do
       context 'when not owned by the user' do
         let(:target) { build(:category, :draft, owned_by: 'no@no.com') }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
+        it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
       end
       context 'when owned by the user' do
         let(:target) { build(:category, :draft, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
     context 'for deleted records' do
       context 'when not owned by the user' do
         let(:target) { build(:category, :deleted, owned_by: 'no@no.com') }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
+        it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
       end
       context 'when owned by the user' do
         let(:target) { build(:category, :deleted, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
     context 'for private records' do
       context 'when not owned by the user' do
         let(:target) { build(:category, :private, owned_by: 'no@no.com') }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
+        it { is_expected.to forbid_action(:update) }
         it { is_expected.to forbid_action(:destroy) }
       end
       context 'when owned by the user' do
         let(:target) { build(:category, :private, owned_by: user.email) }
         it { is_expected.to permit_action(:show) }
-        it { is_expected.to permit_action(:update) }
-        it { is_expected.to permit_action(:destroy) }
+        it { is_expected.to forbid_action(:update) }
+        it { is_expected.to forbid_action(:destroy) }
       end
     end
   end
@@ -358,6 +369,32 @@ RSpec.describe CategoryPolicy, type: :policy do
         it { is_expected.to permit_action(:update) }
         it { is_expected.to permit_action(:destroy) }
       end
+    end
+  end
+
+  # UpdateCategory routes visibility transitions through
+  # BaseMutation#authorize_visibility_transition, which authorizes :soft_delete?
+  # and :restore?. Those must be superuser-gated too, otherwise a non-superuser
+  # could reach a category write through the visibility argument.
+  describe 'visibility-transition actions' do
+    let(:target) { build(:category, :public, owned_by: user.email) }
+
+    context 'when user has write accesss' do
+      let(:user) { build(:user, :readwrite) }
+      it { is_expected.to forbid_action(:soft_delete) }
+      it { is_expected.to forbid_action(:restore) }
+    end
+
+    context 'when user is admin' do
+      let(:user) { build(:user, :admin) }
+      it { is_expected.to forbid_action(:soft_delete) }
+      it { is_expected.to forbid_action(:restore) }
+    end
+
+    context 'when user is super admin' do
+      let(:user) { build(:user, :superadmin) }
+      it { is_expected.to permit_action(:soft_delete) }
+      it { is_expected.to permit_action(:restore) }
     end
   end
 end

--- a/spec/policies/image_policy_spec.rb
+++ b/spec/policies/image_policy_spec.rb
@@ -371,9 +371,9 @@ RSpec.describe ImagePolicy, type: :policy do
 
   context 'when the user owns the associated record' do
     let(:user) { build(:user, :readwrite) }
-    let(:category) { create(:category, owned_by: user.email) }
+    let(:parent_record) { create(:plant, owned_by: user.email) }
     context 'when the user does not own the image' do
-      let(:target) { build(:image, :private, owned_by: 'someone else', imageable: category) }
+      let(:target) { build(:image, :private, owned_by: 'someone else', imageable: parent_record) }
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:update) }
       it { is_expected.to permit_action(:destroy) }

--- a/spec/policies/organization_authorization_matrix_spec.rb
+++ b/spec/policies/organization_authorization_matrix_spec.rb
@@ -464,6 +464,87 @@ RSpec.describe LocationPolicy, type: :policy do
   include_examples 'organization authorization matrix', :location, LocationPolicy
 end
 
+# Categories are deliberately OUTSIDE the organization capability model. They
+# are a curated taxonomy that the mobile app's top-down navigation depends on,
+# so every write requires a system superuser and NO org role -- not even
+# org_admin in the owning organization -- confers write access. The shared
+# matrix above is therefore intentionally not applied here; these examples pin
+# that exclusion so the matrix cannot be silently reinstated for categories.
 RSpec.describe CategoryPolicy, type: :policy do
-  include_examples 'organization authorization matrix', :category, CategoryPolicy
+  let(:org) { create(:organization, :real) }
+
+  let(:record) do
+    create(:category, :private,
+           owned_by: 'legacy-owner@example.org',
+           owner_organization_id: org.id,
+           source_organization_id: org.id)
+  end
+
+  def actor_with_role(org, role, trust: 2)
+    principal    = create(:principal)
+    personal_org = Organization.personal_for!(principal)
+    User.new(
+      'uid' => principal.external_uid,
+      'email' => principal.email,
+      'trust_levels' => { 'plant' => trust },
+      'organizations' => [{ 'id' => org.id, 'name' => org.name, 'roles' => { 'plant' => role } }]
+    ).tap do |u|
+      u.principal = principal
+      u.personal_organization = personal_org
+    end
+  end
+
+  %w[member contributor editor steward org_admin].each do |role|
+    context "when the actor is #{role} in the owning organization" do
+      subject(:policy) { described_class.new(actor_with_role(org, role), record) }
+
+      it 'can still show? the record (reads follow the org model)' do
+        expect(policy.show?).to be true
+      end
+
+      it 'cannot create?' do
+        expect(policy.create?).to be false
+      end
+
+      it 'cannot update?' do
+        expect(policy.update?).to be false
+      end
+
+      it 'cannot soft_delete?' do
+        expect(policy.soft_delete?).to be false
+      end
+
+      it 'cannot restore?' do
+        expect(policy.restore?).to be false
+      end
+
+      it 'cannot destroy?' do
+        expect(policy.destroy?).to be false
+      end
+    end
+  end
+
+  context 'when the actor is a system superuser' do
+    subject(:policy) { described_class.new(actor_with_role(org, 'member', trust: 10), record) }
+
+    it 'can create?' do
+      expect(policy.create?).to be true
+    end
+
+    it 'can update?' do
+      expect(policy.update?).to be true
+    end
+
+    it 'can soft_delete?' do
+      expect(policy.soft_delete?).to be true
+    end
+
+    it 'can restore?' do
+      expect(policy.restore?).to be true
+    end
+
+    it 'can destroy?' do
+      expect(policy.destroy?).to be true
+    end
+  end
 end


### PR DESCRIPTION
Categories are a small, curated taxonomy that the mobile app's top-down navigation depends on (13 in production, all ECHO-owned). `CategoryPolicy` inherited the generic owned-resource rules, so **any trust-2 writer could create a category** in their personal organization, forking the shared taxonomy with near-duplicates. Nothing enforced the curation the data actually relies on.

## Change

Gate `create?` / `update?` / `destroy?` / `soft_delete?` / `restore?` on `super_admin?`, mirroring the other controlled lookup tables (Tolerance, GrowthHabit, Antinutrient, ImageAttribute). `soft_delete?`/`restore?` are included because `UpdateCategory` routes the legacy `visibility` argument through `authorize_visibility_transition`, which authorizes those directly.

**Reads are deliberately untouched.** `index?`/`show?`/`Scope` stay inherited, so public categories remain readable by everyone including anonymous clients, and mobile navigation is unaffected. Associating a record *with* a category is authorized against the owning record's `:update?` in `UpdateRelationsBaseMutation`, so contributors can still categorize their plants.

## Test fallout worth reviewing

`spec/factories/images.rb` defaulted `imageable { create(:category) }`, and `ImagePolicy#imageable_manageable?` delegates to the imageable's `:update?` — so the entire image test surface was implicitly asserting *category* authorization (50 failures). The factory now defaults to `create(:plant)`, an ordinary owned parent, which is what those specs meant to exercise.

A real consequence follows from that same delegation: **images attached to a category are now superuser-only too**, since image rights inherit the parent's `update?`.

`Category` is also removed from the shared `organization authorization matrix` and replaced with an explicit exclusion block asserting that no org role — including `org_admin` in the owning org — confers write access, while `show?` still passes.

## Operational note

The gate is `super_admin?` (plant trust >= 10). No one currently holds trust 10, so **category management is frozen until someone is granted it at the IdP**. This is intentional and accepted: reads and plant-tagging are unaffected, and the 13 existing categories are stable.

### Verification
- `bundle exec rspec` - 1901 examples, **0 failures**
- `bundle exec rubocop` - 619 files, **0 offenses**

🤖 Generated with [Claude Code](https://claude.com/claude-code)