### PR TITLE
fix(resolvers): break sort ties by id so paging cannot skip a record

### DIFF
--- a/app/graphql/resolvers/antinutrients_resolver.rb
+++ b/app/graphql/resolvers/antinutrients_resolver.rb
@@ -10,7 +10,10 @@ module Resolvers
     type Types::AntinutrientType::AntinutrientConnectionWithTotalCountType, null: false
     description 'Returns a list of Antinutrients'
 
-    scope { Antinutrient.all.i18n.order(name: :asc) }
+    # id breaks ties so the offset-paginated connection cannot skip or repeat a
+    # row between pages (see PlantsResolver). Chained, not a second key in the
+    # same hash: .i18n rewrites the translated key and drops the rest.
+    scope { Antinutrient.all.i18n.order(name: :asc).order(id: :asc) }
 
     option :language,
            type: String,

--- a/app/graphql/resolvers/categories_resolver.rb
+++ b/app/graphql/resolvers/categories_resolver.rb
@@ -59,11 +59,25 @@ module Resolvers
     end
 
     def apply_sort_direction_with_asc(scope)
-      scope.order(name: :asc)
+      # The id tiebreaker is not cosmetic. The Relay connection paginates by
+      # OFFSET, so page 2 is a second query with OFFSET 25 rather than a
+      # continuation of the first. Postgres gives no stable order for rows that
+      # tie on the sort key, so without a deterministic final term two equal
+      # rows can swap between those queries and a record is skipped or repeated
+      # across a page boundary. Production has 13 duplicated scientific names.
+      # Chained rather than order(name:, id:): on a Mobility .i18n scope the
+      # translated key is rewritten into a jsonb expression and any other key
+      # in the same hash is silently dropped, so the tiebreaker never reached
+      # the SQL.
+      scope.order(name: :asc).order(id: :asc)
     end
 
     def apply_sort_direction_with_desc(scope)
-      scope.order(name: :desc)
+      # Chained rather than order(name:, id:): on a Mobility .i18n scope the
+      # translated key is rewritten into a jsonb expression and any other key
+      # in the same hash is silently dropped, so the tiebreaker never reached
+      # the SQL.
+      scope.order(name: :desc).order(id: :desc)
     end
 
     def apply_name_filter(scope, value)

--- a/app/graphql/resolvers/growth_habits_resolver.rb
+++ b/app/graphql/resolvers/growth_habits_resolver.rb
@@ -10,7 +10,10 @@ module Resolvers
     type Types::GrowthHabitType::GrowthHabitConnectionWithTotalCountType, null: false
     description 'Returns a list of Growth habits'
 
-    scope { GrowthHabit.all.i18n.order(name: :asc) }
+    # id breaks ties so the offset-paginated connection cannot skip or repeat a
+    # row between pages (see PlantsResolver). Chained, not a second key in the
+    # same hash: .i18n rewrites the translated key and drops the rest.
+    scope { GrowthHabit.all.i18n.order(name: :asc).order(id: :asc) }
 
     option :language,
            type: String,

--- a/app/graphql/resolvers/image_attributes_resolver.rb
+++ b/app/graphql/resolvers/image_attributes_resolver.rb
@@ -10,7 +10,10 @@ module Resolvers
     type Types::ImageAttributeType::ImageAttributeConnectionWithTotalCountType, null: false
     description 'Returns a list of Image Attributes'
 
-    scope { ImageAttribute.all.i18n.order(name: :asc) }
+    # id breaks ties so the offset-paginated connection cannot skip or repeat a
+    # row between pages (see PlantsResolver). Chained, not a second key in the
+    # same hash: .i18n rewrites the translated key and drops the rest.
+    scope { ImageAttribute.all.i18n.order(name: :asc).order(id: :asc) }
 
     option :language,
            type: String,

--- a/app/graphql/resolvers/locations_resolver.rb
+++ b/app/graphql/resolvers/locations_resolver.rb
@@ -82,11 +82,17 @@ module Resolvers
     end
 
     def apply_sort_direction_with_asc(scope)
-      scope.order(name: :asc)
+      # The id tiebreaker is not cosmetic. The Relay connection paginates by
+      # OFFSET, so page 2 is a second query with OFFSET 25 rather than a
+      # continuation of the first. Postgres gives no stable order for rows that
+      # tie on the sort key, so without a deterministic final term two equal
+      # rows can swap between those queries and a record is skipped or repeated
+      # across a page boundary. Production has 13 duplicated scientific names.
+      scope.order(name: :asc, id: :asc)
     end
 
     def apply_sort_direction_with_desc(scope)
-      scope.order(name: :desc)
+      scope.order(name: :desc, id: :desc)
     end
 
     def apply_name_filter(scope, value)

--- a/app/graphql/resolvers/plants_resolver.rb
+++ b/app/graphql/resolvers/plants_resolver.rb
@@ -97,11 +97,17 @@ module Resolvers
     end
 
     def apply_sort_direction_with_asc(scope)
-      scope.order(scientific_name: :asc)
+      # The id tiebreaker is not cosmetic. The Relay connection paginates by
+      # OFFSET, so page 2 is a second query with OFFSET 25 rather than a
+      # continuation of the first. Postgres gives no stable order for rows that
+      # tie on the sort key, so without a deterministic final term two equal
+      # rows can swap between those queries and a record is skipped or repeated
+      # across a page boundary. Production has 13 duplicated scientific names.
+      scope.order(scientific_name: :asc, id: :asc)
     end
 
     def apply_sort_direction_with_desc(scope)
-      scope.order(scientific_name: :desc)
+      scope.order(scientific_name: :desc, id: :desc)
     end
 
     def apply_name_filter(scope, value)

--- a/app/graphql/resolvers/specimens_resolver.rb
+++ b/app/graphql/resolvers/specimens_resolver.rb
@@ -82,11 +82,17 @@ module Resolvers
     end
 
     def apply_sort_direction_with_asc(scope)
-      scope.order(created_at: :asc)
+      # The id tiebreaker is not cosmetic. The Relay connection paginates by
+      # OFFSET, so page 2 is a second query with OFFSET 25 rather than a
+      # continuation of the first. Postgres gives no stable order for rows that
+      # tie on the sort key, so without a deterministic final term two equal
+      # rows can swap between those queries and a record is skipped or repeated
+      # across a page boundary. Production has 13 duplicated scientific names.
+      scope.order(created_at: :asc, id: :asc)
     end
 
     def apply_sort_direction_with_desc(scope)
-      scope.order(created_at: :desc)
+      scope.order(created_at: :desc, id: :desc)
     end
 
     def apply_name_filter(scope, value)

--- a/app/graphql/resolvers/tolerances_resolver.rb
+++ b/app/graphql/resolvers/tolerances_resolver.rb
@@ -10,7 +10,10 @@ module Resolvers
     type Types::ToleranceType::ToleranceConnectionWithTotalCountType, null: false
     description 'Returns a list of Tolerances'
 
-    scope { Tolerance.all.i18n.order(name: :asc) }
+    # id breaks ties so the offset-paginated connection cannot skip or repeat a
+    # row between pages (see PlantsResolver). Chained, not a second key in the
+    # same hash: .i18n rewrites the translated key and drops the rest.
+    scope { Tolerance.all.i18n.order(name: :asc).order(id: :asc) }
 
     option :language,
            type: String,

--- a/app/graphql/resolvers/varieties_resolver.rb
+++ b/app/graphql/resolvers/varieties_resolver.rb
@@ -82,11 +82,25 @@ module Resolvers
     end
 
     def apply_sort_direction_with_asc(scope)
-      scope.order(name: :asc)
+      # The id tiebreaker is not cosmetic. The Relay connection paginates by
+      # OFFSET, so page 2 is a second query with OFFSET 25 rather than a
+      # continuation of the first. Postgres gives no stable order for rows that
+      # tie on the sort key, so without a deterministic final term two equal
+      # rows can swap between those queries and a record is skipped or repeated
+      # across a page boundary. Production has 13 duplicated scientific names.
+      # Chained rather than order(name:, id:): on a Mobility .i18n scope the
+      # translated key is rewritten into a jsonb expression and any other key
+      # in the same hash is silently dropped, so the tiebreaker never reached
+      # the SQL.
+      scope.order(name: :asc).order(id: :asc)
     end
 
     def apply_sort_direction_with_desc(scope)
-      scope.order(name: :desc)
+      # Chained rather than order(name:, id:): on a Mobility .i18n scope the
+      # translated key is rewritten into a jsonb expression and any other key
+      # in the same hash is silently dropped, so the tiebreaker never reached
+      # the SQL.
+      scope.order(name: :desc).order(id: :desc)
     end
 
     def apply_name_filter(scope, value)

--- a/spec/queries/sort_tiebreaker_spec.rb
+++ b/spec/queries/sort_tiebreaker_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Every list query orders by a non-unique key (scientific name, name, created
+# date), and the Relay connection paginates by OFFSET -- page two is a separate
+# query with OFFSET n, not a continuation of page one. Postgres guarantees no
+# particular order for rows that tie on the ORDER BY key, so without a
+# deterministic final term the two queries can disagree about which tied row
+# comes first, and a record is skipped or repeated across the boundary.
+#
+# Each spec edits one record between fetching page one and page two. That is not
+# incidental: at test scale Postgres returns a small unindexed table in physical
+# order and is accidentally stable, so specs without the edit pass with or
+# without the fix and prove nothing. An UPDATE writes a new row version at the
+# end of the heap and genuinely rearranges the scan -- which is also the real
+# scenario, someone saving a record while a colleague pages through the list.
+RSpec.describe 'List sort stability', type: :graphql_query do
+  def page_ids(query_string, user, variables)
+    result = PlantApiSchema.execute(query_string, context: { current_user: user }, variables: variables)
+    expect(result['errors']).to be_nil
+    result['data'].values.first['edges'].map { |e| e['node']['id'] }
+  end
+
+  describe 'plants ordered by a duplicated scientific name' do
+    let(:query_string) do
+      <<-GRAPHQL
+      query($first: Int, $after: String, $sortDirection: SortDirection){
+        plants(first: $first, after: $after, sortDirection: $sortDirection){
+          totalCount
+          edges { node { id } }
+        }
+      }
+      GRAPHQL
+    end
+
+    it 'pages through every record exactly once when names tie and a row is edited mid-paging' do
+      user = build(:user, :readwrite)
+      # Every plant shares one scientific name, so the sort key can never decide
+      # the order: only the tiebreaker can.
+      created = Array.new(9) do
+        create(:plant, scientific_name: 'Cucurbita moschata', visibility: :public, owned_by: user.email)
+      end
+
+      first_page = page_ids(query_string, user, { first: 3 })
+
+      # Someone edits a record while you are paging. An UPDATE writes a new row
+      # version at the end of the heap, so an unordered sequential scan returns
+      # it in a different position than it did a moment ago. That is what turns
+      # the missing tiebreaker from theoretical into a record you never see:
+      # without one, this rearranges the very pages being walked.
+      created.first.update!(family_names: 'Cucurbitaceae')
+
+      second_page = page_ids(query_string, user, { first: 3, after: 'Mw' }) # offset 3
+      third_page = page_ids(query_string, user, { first: 3, after: 'Ng' })  # offset 6
+
+      seen = first_page + second_page + third_page
+      expect(seen.uniq.size).to eq(9), "a record was skipped or repeated across pages: #{seen}"
+      expect(seen.sort).to eq(created.map { |p| PlantApiSchema.id_from_object(p, Plant, {}) }.sort)
+    end
+
+    it 'is a total reversal when the direction flips' do
+      user = build(:user, :readwrite)
+      Array.new(5) do
+        create(:plant, scientific_name: 'Amaranthus caudatus', visibility: :public, owned_by: user.email)
+      end
+
+      ascending = page_ids(query_string, user, { first: 5, sortDirection: 'ASC' })
+      descending = page_ids(query_string, user, { first: 5, sortDirection: 'DESC' })
+
+      # Without the tiebreaker applied in both directions these merely differ;
+      # with it, one is exactly the other reversed.
+      expect(descending).to eq(ascending.reverse)
+    end
+  end
+
+  describe 'specimens ordered by an identical created date' do
+    it 'pages through every record exactly once' do
+      query_string = <<-GRAPHQL
+      query($first: Int, $after: String){
+        specimens(first: $first, after: $after){
+          edges { node { id } }
+        }
+      }
+      GRAPHQL
+
+      user = build(:user, :readwrite)
+      # created_at is the sort key, so make them collide exactly.
+      stamp = Time.zone.parse('2026-01-01 12:00:00')
+      created = Array.new(6) do
+        create(:specimen, visibility: :public, owned_by: user.email, created_at: stamp, updated_at: stamp)
+      end
+
+      first_page = page_ids(query_string, user, { first: 3 })
+      created.first.update!(notes: 'edited while paging')
+      seen = first_page + page_ids(query_string, user, { first: 3, after: 'Mw' })
+
+      expect(seen.uniq.size).to eq(6), "a record was skipped or repeated across pages: #{seen}"
+      expect(seen.sort).to eq(created.map { |s| PlantApiSchema.id_from_object(s, Specimen, {}) }.sort)
+    end
+  end
+
+  describe 'lookups ordered by a duplicated name' do
+    it 'pages through every record exactly once' do
+      query_string = <<-GRAPHQL
+      query($first: Int, $after: String){
+        tolerances(first: $first, after: $after){
+          edges { node { id } }
+        }
+      }
+      GRAPHQL
+
+      user = build(:user, :readwrite)
+      created = Array.new(6) { create(:tolerance, name: 'Drought') }
+
+      first_page = page_ids(query_string, user, { first: 3 })
+      created.first.touch
+      seen = first_page + page_ids(query_string, user, { first: 3, after: 'Mw' })
+
+      expect(seen.uniq.size).to eq(6), "a record was skipped or repeated across pages: #{seen}"
+      expect(seen.sort).to eq(created.map { |t| PlantApiSchema.id_from_object(t, Tolerance, {}) }.sort)
+    end
+  end
+end


### PR DESCRIPTION
A latent bug rather than a missing feature. Every list query orders by a **non-unique** key — scientific name, name, created date — and the Relay connection paginates by **OFFSET**: page two is a separate query with `OFFSET n`, not a continuation of page one. Postgres guarantees no order for rows tied on the `ORDER BY` key, so the two queries can disagree about which tied row comes first, and a record is **skipped or shown twice** across the boundary.

Production has **13 duplicated scientific names**, so it is reachable today.

Appending `id` makes the order total. Applied to plants, specimens, locations, categories, varieties and the four lookups, in both directions.

## Two things worth reading

**1. On a Mobility `.i18n` scope, `order(name: :asc, id: :asc)` silently drops the `id`.**

```sql
-- order(name: :asc, id: :asc)  -- the tiebreaker never arrives
ORDER BY (("tolerances"."translations" -> 'en') ->> 'name') ASC

-- order(name: :asc).order(id: :asc)
ORDER BY (("tolerances"."translations" -> 'en') ->> 'name') ASC, "tolerances"."id" ASC
```

The translated key is rewritten into a jsonb expression and the rest of the hash goes with it. My first version of this fix was therefore a **no-op for every translated name** — categories, varieties and all four lookups. Caught only because a spec still failed afterwards.

**2. The specs edit one record between page one and page two, and that is load-bearing.**

Without the edit they pass with *or* without the fix and prove nothing: at test scale Postgres returns a small unindexed table in physical order and is accidentally stable. An `UPDATE` writes a new row version at the end of the heap and genuinely rearranges the scan — which is also the real-world scenario, someone saving a record while a colleague pages through the list.

Verified both ways:

```
without the fix   4 examples, 4 failures   (e.g. "a record was skipped or repeated across pages")
with the fix      4 examples, 0 failures
```

## Verification

- `bundle exec rspec` — **1919 examples, 0 failures**
- `bundle exec rubocop` — 622 files, no offenses
- Generated SQL checked directly for each translated model

No schema change, no API surface change; `sortDirection` behaves exactly as before, just deterministically. Related: #91 scopes what it would take to widen sorting beyond one key per list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145DvgNvxaMQSi9wxDtAytt