### PR TITLE
fix(authz): close the two gaps blocking the S7 cleanup

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -15,19 +15,44 @@ module Mutations
 
     # Server-assigned ownership/provenance fields for newly created
     # independently-owned records (design.md sections 1 and 4). Never
-    # client-suppliable. Empty when the request has no resolved principal
-    # (schema-level specs, pre-rollout tokens), leaving legacy behavior
-    # untouched. A native record's source organization equals its owner.
+    # client-suppliable. A native record's source organization equals its owner.
+    #
+    # Returns [stamp, error] like acting_organization_stamp, and FAILS CLOSED
+    # when the request has no resolved principal:
+    #
+    #   stamp, err = ownership_stamp
+    #   return { resource: nil, errors: [err] } if err
+    #
+    # It used to return {} in that case, which inserted a row with NULL
+    # ownership columns. resolve_actor deliberately degrades to legacy authz on
+    # a database error rather than 500ing, so a transient blip during a create
+    # produced an unattributable record that nothing would ever repair -- and
+    # S7 puts NOT NULL on exactly those three columns, which would turn the
+    # same request into a raw insert failure. Refusing the write with a
+    # retryable payload error is better than either.
+    def unattributable_error
+      {
+        # MutationError.field is non-null, and this error belongs to no input
+        # field -- the request itself could not be attributed. 'base' is the
+        # Rails convention for a record-level rather than attribute-level error.
+        field: 'base',
+        message: 'Could not resolve the acting identity for this request. Please retry.',
+        code: 503
+      }
+    end
+
     def ownership_stamp
       user = context[:current_user]
-      return {} unless user&.principal
+      return [nil, unattributable_error] unless user&.principal
 
       org_id = user.personal_organization&.id
-      {
+      return [nil, unattributable_error] if org_id.nil?
+
+      [{
         created_by_principal_id: user.principal.id,
         owner_organization_id: org_id,
         source_organization_id: org_id
-      }
+      }, nil]
     end
 
     # Acting-organization stamp: like ownership_stamp but uses the specified
@@ -40,13 +65,9 @@ module Mutations
     #   return { resource: nil, errors: [err] } if err
     def acting_organization_stamp(organization_id)
       user = context[:current_user]
-      unless user&.principal
-        return [{
-          created_by_principal_id: nil,
-          owner_organization_id: nil,
-          source_organization_id: nil
-        }, nil]
-      end
+      # Same reasoning as ownership_stamp: an unattributable create is refused
+      # rather than written with NULL ownership.
+      return [nil, unattributable_error] unless user&.principal
 
       begin
         _type_name, raw_id = GraphQL::Schema::UniqueWithinType.decode(organization_id)

--- a/app/graphql/mutations/create_category.rb
+++ b/app/graphql/mutations/create_category.rb
@@ -30,14 +30,14 @@ module Mutations
       language = attributes[:language] || I18n.locale
 
       org_id_arg = attributes.delete(:organization_id)
-      if org_id_arg
-        stamp, err = acting_organization_stamp(org_id_arg)
-        return { category: nil, errors: [err] } if err
+      stamp, err = if org_id_arg
+                     acting_organization_stamp(org_id_arg)
+                   else
+                     ownership_stamp
+                   end
+      return { category: nil, errors: [err] } if err
 
-        org_stamp = stamp
-      else
-        org_stamp = ownership_stamp
-      end
+      org_stamp = stamp
 
       attributes
         .except!(:language)

--- a/app/graphql/mutations/create_location.rb
+++ b/app/graphql/mutations/create_location.rb
@@ -52,14 +52,14 @@ module Mutations
 
     def resolve(**attributes)
       org_id_arg = attributes.delete(:organization_id)
-      if org_id_arg
-        stamp, err = acting_organization_stamp(org_id_arg)
-        return { location: nil, errors: [err] } if err
+      stamp, err = if org_id_arg
+                     acting_organization_stamp(org_id_arg)
+                   else
+                     ownership_stamp
+                   end
+      return { location: nil, errors: [err] } if err
 
-        org_stamp = stamp
-      else
-        org_stamp = ownership_stamp
-      end
+      org_stamp = stamp
 
       attributes
         .merge!(created_by: context[:current_user].email)

--- a/app/graphql/mutations/create_plant.rb
+++ b/app/graphql/mutations/create_plant.rb
@@ -43,14 +43,14 @@ module Mutations
       primary_common_name = attributes[:primary_common_name]
 
       org_id_arg = attributes.delete(:organization_id)
-      if org_id_arg
-        stamp, err = acting_organization_stamp(org_id_arg)
-        return { plant: nil, errors: [err] } if err
+      stamp, err = if org_id_arg
+                     acting_organization_stamp(org_id_arg)
+                   else
+                     ownership_stamp
+                   end
+      return { plant: nil, errors: [err] } if err
 
-        org_stamp = stamp
-      else
-        org_stamp = ownership_stamp
-      end
+      org_stamp = stamp
 
       attributes
         .except!(:language)

--- a/app/graphql/mutations/create_specimen.rb
+++ b/app/graphql/mutations/create_specimen.rb
@@ -62,14 +62,14 @@ module Mutations
       return { specimen: nil, errors: errors } if errors.any?
 
       org_id_arg = attributes.delete(:organization_id)
-      if org_id_arg
-        stamp, err = acting_organization_stamp(org_id_arg)
-        return { specimen: nil, errors: [err] } if err
+      stamp, err = if org_id_arg
+                     acting_organization_stamp(org_id_arg)
+                   else
+                     ownership_stamp
+                   end
+      return { specimen: nil, errors: [err] } if err
 
-        org_stamp = stamp
-      else
-        org_stamp = ownership_stamp
-      end
+      org_stamp = stamp
 
       attributes
         .except!(:plant_id, :variety_id)

--- a/app/graphql/mutations/create_variety.rb
+++ b/app/graphql/mutations/create_variety.rb
@@ -44,14 +44,14 @@ module Mutations
       language = attributes[:language] || I18n.locale
 
       org_id_arg = attributes.delete(:organization_id)
-      if org_id_arg
-        stamp, err = acting_organization_stamp(org_id_arg)
-        return { variety: nil, errors: [err] } if err
+      stamp, err = if org_id_arg
+                     acting_organization_stamp(org_id_arg)
+                   else
+                     ownership_stamp
+                   end
+      return { variety: nil, errors: [err] } if err
 
-        org_stamp = stamp
-      else
-        org_stamp = ownership_stamp
-      end
+      org_stamp = stamp
 
       attributes
         .except!(:language)

--- a/app/policies/specimen_policy.rb
+++ b/app/policies/specimen_policy.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
-# Defines the unique secuirty policy for Category objects
+# Specimens are the one owned type with no soft delete.
 class SpecimenPolicy < OwnedResourcePolicy
+  # DeleteSpecimen is a hard delete, and SpecimenType#canDelete maps to
+  # destroy?. The base destroy? has no organization branch at all -- its
+  # org_granted argument is hardcoded false -- so once S7 removes the legacy
+  # email rule it would collapse to superuser-only, and ordinary members would
+  # lose the ability to remove their own specimens entirely. That is not the
+  # intent: a specimen is a personal planting record, and the person keeping it
+  # should be able to delete it.
+  #
+  # Mapped onto :soft_delete rather than a new :destroy capability, for two
+  # reasons. Adding a destroy capability was considered and rejected -- soft
+  # delete exists for a reason on the types that have it. And for those types
+  # :soft_delete already means "the right to remove this from the working set";
+  # specimens simply have no softer option, so it is the same right expressed
+  # against the only mechanism they have.
+  #
+  # Deliberately NOT applied to Category, the other type whose canDelete maps
+  # to destroy?: categories are a curated taxonomy the mobile navigation
+  # depends on, and their writes are superuser-only by decision.
+  def destroy?
+    return false unless user&.can_write?
+
+    legacy = user.super_admin? || record.owned_by == user.email
+    org_granted = organization_capability?(:soft_delete)
+    log_legacy_divergence(:destroy, legacy, org_granted)
+    legacy || org_granted
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,31 @@ FactoryBot.define do
     uid { Faker::Internet.uuid }
     trust_levels { { 'plant' => 4 } }
     initialize_with { new(attributes.stringify_keys) }
+
+    # Every real request resolves a principal and a personal organization in
+    # ApplicationController#resolve_actor before any policy or mutation runs;
+    # the only way they are nil in production is a database failure, which the
+    # controller deliberately degrades to legacy authz. A built user without
+    # them therefore models a failure mode, not the normal case -- and create
+    # mutations now refuse to write unattributable rows, so specs that build a
+    # bare user were exercising that failure path by accident.
+    #
+    # Use the :unresolved trait to model the failure deliberately.
+    after(:build) do |user|
+      next if user.instance_variable_get(:@skip_principal)
+
+      principal = Principal.resolve!(issuer: 'spec', external_uid: user.id, email: user.email)
+      user.principal = principal
+      user.personal_organization = Organization.personal_for!(principal)
+    end
+
+    # A request whose identity could not be resolved (resolve_actor degraded).
+    trait :unresolved do
+      after(:build) do |user|
+        user.principal = nil
+        user.personal_organization = nil
+      end
+    end
     trait :readonly do
       trust_levels { { 'plant' => 1 } }
     end

--- a/spec/mutations/protected_ownership_fields_spec.rb
+++ b/spec/mutations/protected_ownership_fields_spec.rb
@@ -125,28 +125,29 @@ RSpec.describe 'Protected ownership fields', type: :graphql_mutation do
       expect(plant.owner_organization_id).to eq(write_user.personal_organization.id)
     end
 
-    it 'sets created_by_principal_id to nil when no principal is attached (schema-level call)' do
+    # Was: "sets created_by_principal_id to nil when no principal is attached".
+    # That documented the gap S7 could not ship over -- a create with no
+    # resolved identity wrote NULL into the three columns S7 makes NOT NULL.
+    # The write is now refused instead. See spec/mutations/unattributable_create_spec.rb.
+    it 'refuses the write when no principal is attached (schema-level call)' do
       no_principal_user = User.new(
         'uid' => nil,
         'email' => 'noprincipal@example.org',
         'trust_levels' => { 'plant' => 2 },
         'organizations' => []
       )
-      result = PlantApiSchema.execute(
-        query_string,
-        context: { current_user: no_principal_user },
-        variables: { input: { primaryCommonName: 'No Principal Plant', language: 'en' } }
-      )
-      # No principal: the mutation should still succeed with nil ownership fields
-      plant_id = result.dig('data', 'createPlant', 'plant', 'id')
-      if plant_id
-        plant = PlantApiSchema.object_from_id(plant_id, {})
-        expect(plant.created_by_principal_id).to be_nil
-        expect(plant.owner_organization_id).to be_nil
-      else
-        # If the auth check prevents it, just verify no 5xx
-        expect(result['errors']).to be_present
-      end
+      result = nil
+      expect do
+        result = PlantApiSchema.execute(
+          query_string,
+          context: { current_user: no_principal_user },
+          variables: { input: { primaryCommonName: 'No Principal Plant', language: 'en' } }
+        )
+      end.not_to change(Plant, :count)
+
+      payload = result.dig('data', 'createPlant')
+      expect(payload['plant']).to be_nil
+      expect(payload['errors'].map { |e| e['code'] }).to include(503)
     end
   end
 

--- a/spec/mutations/unattributable_create_spec.rb
+++ b/spec/mutations/unattributable_create_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# S7 puts NOT NULL on created_by_principal_id, owner_organization_id and
+# source_organization_id. Nothing may write NULL into them before then.
+#
+# The path that could is ApplicationController#resolve_actor, which degrades to
+# legacy authorization on a database error rather than returning 500 -- leaving
+# principal and personal_organization nil while the request proceeds. A create
+# in that state used to succeed and insert an unattributable row that nothing
+# would ever repair.
+RSpec.describe 'Creating without a resolved identity', type: :graphql_query do
+  let(:query_string) do
+    <<-GRAPHQL
+      mutation($input: CreatePlantInput!){
+        createPlant(input: $input){
+          plant { id ownerOrganization { id } }
+          errors { field message code }
+        }
+      }
+    GRAPHQL
+  end
+
+  def create_plant(user)
+    PlantApiSchema.execute(
+      query_string,
+      context: { current_user: user },
+      variables: { input: { primaryCommonName: 'Unattributable', language: 'en' } }
+    )
+  end
+
+  it 'refuses the write and says so, rather than inserting NULL ownership' do
+    user = build(:user, :readwrite, :unresolved)
+
+    expect { @result = create_plant(user) }.not_to change(Plant, :count)
+
+    expect(@result['errors']).to be_nil, "query error: #{@result['errors'].inspect}"
+    payload = @result['data']['createPlant']
+    expect(payload['plant']).to be_nil
+    expect(payload['errors'].first['code']).to eq 503
+    expect(payload['errors'].first['message']).to match(/could not resolve/i)
+  end
+
+  it 'stamps ownership normally once the identity resolves' do
+    user = build(:user, :readwrite)
+
+    expect { @result = create_plant(user) }.to change(Plant, :count).by(1)
+
+    payload = @result['data']['createPlant']
+    expect(payload['errors']).to be_empty
+    expect(payload['plant']['ownerOrganization']).not_to be_nil
+
+    plant = Plant.find_by(id: Plant.last.id)
+    expect(plant.owner_organization_id).not_to be_nil
+    expect(plant.source_organization_id).not_to be_nil
+    expect(plant.created_by_principal_id).not_to be_nil
+  end
+
+  # The same guarantee has to hold for every create that stamps ownership, or
+  # S7's NOT NULL lands on a table another mutation can still violate. Each one
+  # needs its own required inputs, so the shapes are spelled out rather than
+  # shared.
+  it 'createCategory also refuses an unattributable write' do
+    expect(unattributable_codes('createCategory', 'CreateCategoryInput',
+                                { name: 'Unattributable', language: 'en' })).to include(503)
+  end
+
+  it 'createLocation also refuses an unattributable write' do
+    expect(unattributable_codes('createLocation', 'CreateLocationInput',
+                                { name: 'Unattributable', soilQuality: 'GOOD' })).to include(503)
+  end
+
+  it 'createSpecimen also refuses an unattributable write' do
+    plant = create(:plant)
+    plant_id = PlantApiSchema.id_from_object(plant, Plant, {})
+    expect(unattributable_codes('createSpecimen', 'CreateSpecimenInput',
+                                { name: 'Unattributable', plantId: plant_id })).to include(503)
+  end
+
+  def unattributable_codes(field, input_type, input)
+    user = build(:user, :superadmin, :unresolved)
+    mutation = <<-GRAPHQL
+      mutation($input: #{input_type}!){
+        #{field}(input: $input){ errors { field message code } }
+      }
+    GRAPHQL
+
+    result = PlantApiSchema.execute(mutation, context: { current_user: user },
+                                              variables: { input: input })
+    expect(result['errors']).to be_nil, "query error: #{result['errors'].inspect}"
+    result['data'][field]['errors'].map { |e| e['code'] }
+  end
+end

--- a/spec/policies/organization_authorization_matrix_spec.rb
+++ b/spec/policies/organization_authorization_matrix_spec.rb
@@ -34,7 +34,7 @@ end
 # ---------------------------------------------------------------------------
 # Shared examples: parameterised per independently-owned model
 # ---------------------------------------------------------------------------
-RSpec.shared_examples 'organization authorization matrix' do |factory_name, policy_class|
+RSpec.shared_examples 'organization authorization matrix' do |factory_name, policy_class, org_can_destroy: false|
   let(:org) { create(:organization, :real) }
   let(:org_b) { create(:organization, :real) }
 
@@ -202,8 +202,16 @@ RSpec.shared_examples 'organization authorization matrix' do |factory_name, poli
       expect(policy.restore?).to be true
     end
 
-    it 'cannot destroy? (hard delete stays superuser/legacy-owner only)' do
-      expect(policy.destroy?).to be false
+    # Same rule as org_admin below: destroy? has no capability of its own, so a
+    # role that can soft-delete can hard-delete only where no soft delete exists.
+    if org_can_destroy
+      it 'can destroy? (no soft delete exists for this type)' do
+        expect(policy.destroy?).to be true
+      end
+    else
+      it 'cannot destroy? (hard delete stays superuser/legacy-owner only)' do
+        expect(policy.destroy?).to be false
+      end
     end
   end
 
@@ -225,8 +233,18 @@ RSpec.shared_examples 'organization authorization matrix' do |factory_name, poli
       expect(policy.restore?).to be true
     end
 
-    it 'cannot destroy? (no hard-delete hook for org_admin yet)' do
-      expect(policy.destroy?).to be false
+    # Hard delete has no organization capability of its own: it is superuser-only
+    # by decision, because the types that need a reversible removal have soft
+    # delete. Specimens are the exception -- they have no soft delete at all, so
+    # SpecimenPolicy maps destroy? onto :soft_delete (see SpecimenPolicy).
+    if org_can_destroy
+      it 'can destroy? (no soft delete exists for this type)' do
+        expect(policy.destroy?).to be true
+      end
+    else
+      it 'cannot destroy? (hard delete is superuser-only for this type)' do
+        expect(policy.destroy?).to be false
+      end
     end
   end
 
@@ -457,7 +475,8 @@ RSpec.describe VarietyPolicy, type: :policy do
 end
 
 RSpec.describe SpecimenPolicy, type: :policy do
-  include_examples 'organization authorization matrix', :specimen, SpecimenPolicy
+  # org_can_destroy: a specimen has no soft delete, so removing one *is* destroy?.
+  include_examples 'organization authorization matrix', :specimen, SpecimenPolicy, org_can_destroy: true
 end
 
 RSpec.describe LocationPolicy, type: :policy do


### PR DESCRIPTION
The two code gaps documented as blocking S7. These are the **prerequisites**, not S7 itself — S7 proper (removing the legacy branches, the trust-9 override, and adding `NOT NULL`) is the follow-up, and it cannot ship safely until these land.

## Gap 1 — `destroy?` had no organization path

```ruby
legacy = user.super_admin? || record.owned_by == user.email
log_legacy_divergence(:destroy, legacy, false)   # org_granted hardcoded false
legacy
```

Strip the legacy branch and this collapses to **superuser-only**. For most types that is intended: hard delete stays a superuser act *because those types have soft delete*.

**Specimens do not.** `DeleteSpecimen` is a hard delete and `SpecimenType#canDelete` maps to `destroy?`, so ordinary members would have lost the ability to remove their own specimens entirely — and a specimen is a personal planting record.

`SpecimenPolicy#destroy?` now maps onto `:soft_delete`, which for every other type already means *"the right to remove this from the working set"*. Specimens simply have no softer option. **No new `destroy` capability was added** — that was considered and rejected, because soft delete exists for a reason on the types that have it. Category, the other type whose `canDelete` maps to `destroy?`, is deliberately left superuser-only.

## Gap 2 — the ownership stamp failed open to NULLs

`resolve_actor` degrades to legacy authz on a database error rather than returning 500. A create in that state inserted a row with **NULL** `created_by_principal_id` / `owner_organization_id` / `source_organization_id` — unattributable, and nothing would ever repair it. S7 puts `NOT NULL` on exactly those three columns, which would turn the same request into a raw insert failure.

Both stamps now return `[stamp, error]` and refuse the write with a retryable payload error (503, field `base` — `MutationError.field` is non-null). That is better than an unattributable row *and* better than the insert failure it would become after S7.

## The factory change, and why

Making the stamp fail closed broke every create spec, because they `build(:user)` with no principal. That is the right signal, not an obstacle: **every real request resolves an actor before any mutation runs**, so a bare built user models a failure mode. The factory now resolves a principal, and an `:unresolved` trait models the failure deliberately — which is what the new specs use.

## Two existing specs asserted the old behaviour

Updated, not worked around. One was literally named *"cannot destroy? (no hard-delete hook for org_admin yet)"* and the other *"sets created_by_principal_id to nil"* — both were documenting the gaps this PR closes.

## Verification

- **1924 examples, 0 failures**; RuboCop clean, 623 files
- **The new specs fail against the unfixed code — 6 failures before, 0 after.** Checked by reverting `app/graphql/mutations/` and `specimen_policy.rb` and re-running, because a test that passes either way proves nothing

## Not in this PR

S7 proper: removing the legacy email branches and trust-9 override, the `NOT NULL` migration (needs the `ADD CONSTRAINT NOT VALID` → `VALIDATE` → `SET NOT NULL` sequence to avoid a full-table lock), and removing the deprecated-field logging. Gated on a clean `ownership:verify` against production immediately beforehand.

The other S7 prerequisite — that elevated accounts hold equivalent org memberships — was verified satisfied on 2026-08-03: exactly one account at plant trust ≥ 9, already holding `ECHO:org_admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145DvgNvxaMQSi9wxDtAytt