### PR TITLE
S7 tooling: pre-flight audit and staging rehearsal

### DIFF
--- a/.github/workflows/ops-ownership-backfill.yml
+++ b/.github/workflows/ops-ownership-backfill.yml
@@ -56,12 +56,14 @@ on:
           - staging
           - production
       action:
-        description: "Rake task to run (report=read-only stats, verify=invariant check, backfill=fill columns)"
+        description: "Task to run (report=read-only stats, verify=invariant check, preflight=S7 access-loss audit, backfill=fill columns)"
         required: true
         type: choice
         options:
           - report
           - verify
+          - preflight
+          - backfill_staging_rehearsal
           - backfill
       dry_run:
         description: "DRY_RUN=1 (default TRUE -- no DB writes). Set FALSE only with confirm_real_run."
@@ -103,11 +105,15 @@ jobs:
     name: Safety gate check
     runs-on: ubuntu-latest
     steps:
+      # Covers the staging rehearsal too: it writes principals, organizations
+      # and ownership columns just as the real backfill does, so it earns the
+      # same confirmation. The rehearsal being staging-only is a reason for
+      # fewer consequences, not for fewer gates.
       - name: Fail if real backfill requested without confirmation
-        if: inputs.action == 'backfill' && inputs.dry_run == false
+        if: (inputs.action == 'backfill' || inputs.action == 'backfill_staging_rehearsal') && inputs.dry_run == false
         run: |
           if [ "${{ inputs.confirm_real_run }}" != "RUN-REAL-BACKFILL" ]; then
-            echo "::error::SAFETY GATE: action=backfill with dry_run=FALSE requires"
+            echo "::error::SAFETY GATE: a writing backfill with dry_run=FALSE requires"
             echo "::error::  confirm_real_run to equal exactly 'RUN-REAL-BACKFILL'."
             echo "::error::  Got: '${{ inputs.confirm_real_run }}'"
             echo "::error::  Re-run the workflow and type RUN-REAL-BACKFILL in that field."
@@ -165,6 +171,40 @@ jobs:
               ;;
             verify)
               RAKE_CMD="bundle exec rake ownership:verify"
+              ;;
+            preflight)
+              # S7 pre-flight: which records become unreachable once the legacy
+              # email rule goes away. A personal organization whose principal has
+              # no external_uid can never be resolved from a JWT, so nobody can
+              # reach its records -- the gap ownership:verify does not cover.
+              #
+              # NOTE: a one-off task runs the image that is CURRENTLY DEPLOYED,
+              # so this action only works once the commit adding the task has
+              # been deployed to the target environment. That is deliberate:
+              # this tooling ships on its own, ahead of the S7 change it exists
+              # to gate, so the audit can answer for production BEFORE the risky
+              # change is anywhere near it.
+              RAKE_CMD="bundle exec rake ownership:preflight"
+              ;;
+            backfill_staging_rehearsal)
+              # Fills ownership on STAGING so S7 can be rehearsed against
+              # prod-sized data. Staging was never backfilled -- 2,680 records,
+              # zero organizations -- so the NOT NULL migration cannot apply
+              # there and nothing downstream of it can be tested.
+              #
+              # Synthesizes a mapping from staging's own data: fake uids, real
+              # shape. See lib/tasks/staging_rehearsal.rake for why that is
+              # sufficient for a rehearsal, and for the second guard. This one
+              # is the first: never anywhere but staging.
+              if [ "${{ inputs.environment }}" != "staging" ]; then
+                echo "::error::backfill_staging_rehearsal fabricates identities and is staging-only."
+                exit 1
+              fi
+              DR_FLAG="DRY_RUN=1"
+              if [ "$DRY_RUN" = "false" ]; then
+                DR_FLAG="DRY_RUN=0"
+              fi
+              RAKE_CMD="bundle exec rake ownership:staging_rehearsal ${DR_FLAG}"
               ;;
             backfill)
               DR_FLAG="DRY_RUN=1"

--- a/lib/staging_rehearsal_mapping.rb
+++ b/lib/staging_rehearsal_mapping.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'json'
+
+# Builds a synthetic identity mapping for rehearsing the S7 cleanup on staging.
+#
+# Staging was never backfilled: ~2,680 owned records and zero organizations. The
+# NOT NULL migration cannot apply there, so nothing downstream of it can be
+# tested either. The real backfill needs the IdP identity export, which is PII
+# and is deliberately not retained after a run (rollout.md).
+#
+# For a rehearsal the real uids do not matter -- they exist to match real JWTs,
+# and nothing logs into staging with a production token. What matters is the
+# SHAPE: every owner resolved to a principal that carries an external_uid, each
+# with a personal organization, so staging ends up structurally like production
+# rather than like a pre-backfill database.
+#
+# So this fabricates uids. That is only ever acceptable in staging, and it is
+# guarded twice, neither guard sufficient alone:
+#
+#   1. The ops workflow refuses the action unless environment=staging.
+#   2. write! below refuses any database but Plant_API_staging.
+#
+# Guard 2 is the load-bearing one: it asks the live connection what database it
+# is attached to, so it holds even when the task is invoked by hand with the
+# wrong credentials.
+module StagingRehearsalMapping
+  STAGING_DATABASE = 'Plant_API_staging'
+  # Kept out of `users` on purpose so the backfill routes it down its
+  # shared-email path to a service principal, exactly as it did in production.
+  SHARED_EMAILS = ['echo@echonet.org'].freeze
+  ECHO_ORG_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeffff0001'
+  PATH = '/tmp/staging_rehearsal_mapping.json'
+  OWNED_TABLES = %w[plants varieties specimens locations categories].freeze
+
+  module_function
+
+  def write!
+    guard_staging!
+    users = owner_emails.map { |email| user_entry(email) }
+    File.write(PATH, JSON.pretty_generate(
+                       'users' => users,
+                       'organizations' => [{ 'id' => ECHO_ORG_ID, 'name' => 'ECHO (staging rehearsal)' }]
+                     ))
+    users
+  end
+
+  def guard_staging!
+    current = ActiveRecord::Base.connection.current_database
+    return if current == STAGING_DATABASE
+
+    raise 'REFUSING: the staging rehearsal fabricates identities and runs only against ' \
+          "#{STAGING_DATABASE}. Connected to: #{current.inspect}"
+  end
+
+  def owner_emails
+    connection = ActiveRecord::Base.connection
+    OWNED_TABLES.flat_map do |table|
+      %w[owned_by created_by].flat_map do |column|
+        connection.select_values(
+          "SELECT DISTINCT #{column} FROM #{table} WHERE #{column} IS NOT NULL AND #{column} <> ''"
+        )
+      end
+    end.uniq - SHARED_EMAILS
+  end
+
+  # Deterministic, so re-running the rehearsal reuses the same identity rather
+  # than minting a second one for the same person.
+  def user_entry(email)
+    digest = Digest::SHA256.hexdigest("staging-rehearsal:#{email}")
+    uid = [digest[0, 8], digest[8, 4], "4#{digest[13, 3]}",
+           "8#{digest[17, 3]}", digest[20, 12]].join('-')
+    { 'uid' => uid, 'email' => email, 'name' => email.split('@').first }
+  end
+end

--- a/lib/tasks/ownership.rake
+++ b/lib/tasks/ownership.rake
@@ -282,16 +282,15 @@ namespace :ownership do
     at_risk = Hash.new { |h, k| h[k] = Hash.new(0) }
     totals = { real_org: 0, personal_reachable: 0, personal_unreachable: 0, unbackfilled: 0 }
 
-    # Counted separately and FIRST, because the reachability query below joins
-    # on owner_organization_id and so cannot see these rows at all. Without
-    # this, a database that was never backfilled reports a serene PASS while
-    # being the single least ready state for S7 -- the NOT NULL migration
-    # cannot even apply. Ask how a check can lie before trusting it.
     owned_models.each do |model|
+      # Counted, and reported before anything else, because the reachability
+      # query below JOINs on owner_organization_id and so cannot see these rows
+      # at all. Without it a database that was never backfilled reports a
+      # serene PASS while being the single least ready state for S7 -- the NOT
+      # NULL migration cannot even apply. Ask how a check can lie before
+      # trusting what it tells you.
       totals[:unbackfilled] += model.where(owner_organization_id: nil).count
-    end
 
-    owned_models.each do |model|
       rows = model.connection.select_all(<<~SQL.squish)
         SELECT o.kind AS org_kind,
                p.external_uid IS NULL AS unreachable,

--- a/lib/tasks/ownership.rake
+++ b/lib/tasks/ownership.rake
@@ -251,4 +251,101 @@ namespace :ownership do
 
     puts '=' * 60
   end
+  # ---------------------------------------------------------------------------
+  # ownership:preflight
+  # ---------------------------------------------------------------------------
+  desc <<~DESC
+    S7 pre-flight: who would LOSE access when the legacy email rule is removed.
+    Read-only. Exits 1 if any record is unreachable by its owner post-S7.
+  DESC
+  task preflight: :environment do
+    puts 'ownership:preflight'
+    puts '=' * 60
+    puts <<~EXPLAIN
+
+      After S7, reading your own record requires its owner_organization_id to be
+      one your token can reach. Your personal organization is resolved from the
+      JWT by (identity_issuer, external_uid) -- NOT by email. So a record whose
+      owning personal organization belongs to a principal with a NULL
+      external_uid is unreachable by anyone: no token can ever resolve to that
+      principal. Those principals came from the backfill's legacy-email path,
+      for owners whose IdP uid was not in the mapping.
+
+      This is the gap ownership:verify does not cover (it checks for NULL
+      columns, not whether the non-NULL value is reachable), and that the S6
+      divergence soak could not cover either (it only observed users who
+      actually made requests during the window).
+
+    EXPLAIN
+
+    owned_models = [Plant, Variety, Specimen, Location, Category]
+    at_risk = Hash.new { |h, k| h[k] = Hash.new(0) }
+    totals = { real_org: 0, personal_reachable: 0, personal_unreachable: 0, unbackfilled: 0 }
+
+    # Counted separately and FIRST, because the reachability query below joins
+    # on owner_organization_id and so cannot see these rows at all. Without
+    # this, a database that was never backfilled reports a serene PASS while
+    # being the single least ready state for S7 -- the NOT NULL migration
+    # cannot even apply. Ask how a check can lie before trusting it.
+    owned_models.each do |model|
+      totals[:unbackfilled] += model.where(owner_organization_id: nil).count
+    end
+
+    owned_models.each do |model|
+      rows = model.connection.select_all(<<~SQL.squish)
+        SELECT o.kind AS org_kind,
+               p.external_uid IS NULL AS unreachable,
+               p.email AS principal_email,
+               COUNT(*) AS n
+        FROM #{model.table_name} r
+        JOIN organizations o ON o.id = r.owner_organization_id
+        LEFT JOIN principals p ON p.id = o.principal_id
+        GROUP BY o.kind, (p.external_uid IS NULL), p.email
+      SQL
+
+      rows.each do |row|
+        count = row['n'].to_i
+        if row['org_kind'] == 'real'
+          totals[:real_org] += count
+        elsif ActiveModel::Type::Boolean.new.cast(row['unreachable'])
+          totals[:personal_unreachable] += count
+          at_risk[row['principal_email']][model.table_name] += count
+        else
+          totals[:personal_reachable] += count
+        end
+      end
+    end
+
+    puts 'RECORDS BY OWNERSHIP REACHABILITY'
+    puts "  NOT BACKFILLED (owner_organization_id IS NULL):                  #{totals[:unbackfilled]}"
+    puts '  owned by a REAL organization (access via membership claims,'
+    puts "    not verifiable from here -- confirm the claims exist in the IdP): #{totals[:real_org]}"
+    puts "  owned by a personal org with a resolvable principal (healthy): #{totals[:personal_reachable]}"
+    puts "  owned by a personal org with NO external_uid (UNREACHABLE):     #{totals[:personal_unreachable]}"
+
+    if totals[:unbackfilled].positive?
+      puts "\nNOT READY: #{totals[:unbackfilled]} records have no owner organization at all."
+      puts 'This database has not been through the S3 backfill. S7 cannot ship'
+      puts 'against it -- the NOT NULL migration would fail on these rows -- and'
+      puts 'the reachability audit above is meaningless, because it can only see'
+      puts 'records that HAVE an owner organization.'
+      puts '=' * 60
+      abort "FAIL: #{totals[:unbackfilled]} records not backfilled."
+    end
+
+    if at_risk.empty?
+      puts "\nPASS: every personally-owned record is reachable by its owner after S7."
+      puts '=' * 60
+      next
+    end
+
+    puts "\nAT RISK -- these owners cannot reach these records once the legacy"
+    puts 'email rule is removed. Each needs its principal linked to an IdP uid,'
+    puts 'or its records repointed, BEFORE S7 ships:'
+    at_risk.sort_by { |_email, tables| -tables.values.sum }.each do |email, tables|
+      puts "  #{email || '(no email)'}: #{tables.values.sum} records #{tables.inspect}"
+    end
+    puts '=' * 60
+    abort "FAIL: #{totals[:personal_unreachable]} records across #{at_risk.size} owner(s) would become unreachable."
+  end
 end

--- a/lib/tasks/staging_rehearsal.rake
+++ b/lib/tasks/staging_rehearsal.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/staging_rehearsal_mapping')
+
+# Staging-only tooling for rehearsing the S7 cleanup against prod-sized data.
+# The reasoning, and both guards, live in lib/staging_rehearsal_mapping.rb.
+namespace :ownership do
+  desc 'STAGING ONLY: synthesize an identity mapping from the database itself'
+  task synthesize_mapping: :environment do
+    users = StagingRehearsalMapping.write!
+    puts "MAPPING_SYNTHESIZED users=#{users.size}"
+    puts "MAPPING_PATH #{StagingRehearsalMapping::PATH}"
+    puts "ECHO_ORG_ID #{StagingRehearsalMapping::ECHO_ORG_ID}"
+  rescue RuntimeError => e
+    abort e.message
+  end
+
+  desc 'STAGING ONLY: synthesize a mapping and back-fill with it (DRY_RUN=1 by default)'
+  task staging_rehearsal: :environment do
+    Rake::Task['ownership:synthesize_mapping'].invoke
+
+    ENV['MAPPING'] = StagingRehearsalMapping::PATH
+    ENV['ECHO_ORG_ID'] = StagingRehearsalMapping::ECHO_ORG_ID
+    ENV['DRY_RUN'] = ENV.fetch('DRY_RUN', '1')
+    puts "\nRunning ownership:backfill with the synthesized mapping (DRY_RUN=#{ENV.fetch('DRY_RUN')})"
+    Rake::Task['ownership:backfill'].invoke
+  end
+end

--- a/spec/lib/staging_rehearsal_mapping_spec.rb
+++ b/spec/lib/staging_rehearsal_mapping_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/staging_rehearsal_mapping')
+
+# This module fabricates identities. The only thing keeping that out of
+# production is the database guard, so the guard gets tested first and hardest.
+RSpec.describe StagingRehearsalMapping do
+  describe '.guard_staging!' do
+    it 'refuses any database that is not the staging one' do
+      expect { described_class.guard_staging! }
+        .to raise_error(/REFUSING.*Plant_API_staging/m)
+    end
+
+    it 'names the database it actually found, so a misfire is diagnosable' do
+      expect { described_class.guard_staging! }.to raise_error(/#{Regexp.escape(ActiveRecord::Base.connection.current_database)}/)
+    end
+
+    it 'allows the staging database' do
+      allow(ActiveRecord::Base.connection).to receive(:current_database).and_return('Plant_API_staging')
+      expect { described_class.guard_staging! }.not_to raise_error
+    end
+  end
+
+  describe '.write!' do
+    it 'refuses to write anything outside staging' do
+      expect { described_class.write! }.to raise_error(/REFUSING/)
+    end
+  end
+
+  describe '.user_entry' do
+    it 'is deterministic, so a re-run reuses the identity instead of minting a second' do
+      expect(described_class.user_entry('a@b.com')).to eq(described_class.user_entry('a@b.com'))
+    end
+
+    it 'gives different emails different uids' do
+      expect(described_class.user_entry('a@b.com')['uid'])
+        .not_to eq described_class.user_entry('c@d.com')['uid']
+    end
+
+    it 'produces a uid postgres will accept as a uuid' do
+      uid = described_class.user_entry('a@b.com')['uid']
+      expect(uid).to match(/\A\h{8}-\h{4}-4\h{3}-8\h{3}-\h{12}\z/)
+      expect { Principal.create!(identity_issuer: 'spec', external_uid: uid, email: 'a@b.com', kind: 'human') }
+        .not_to raise_error
+    end
+  end
+
+  describe '.owner_emails' do
+    it 'excludes the shared address so the backfill still routes it to a service principal' do
+      allow(ActiveRecord::Base.connection).to receive(:select_values).and_return(
+        ['echo@echonet.org', 'someone@example.com']
+      )
+      expect(described_class.owner_emails).to eq ['someone@example.com']
+    end
+  end
+end

--- a/spec/tasks/ownership_preflight_spec.rb
+++ b/spec/tasks/ownership_preflight_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# The S7 pre-flight audit is only worth running if it can actually fail, so
+# these specs build the unreachable case on purpose and assert it is caught.
+RSpec.describe 'ownership:preflight', type: :task do
+  before(:all) do
+    Rake::Task.clear
+    Rails.application.load_tasks
+  end
+
+  before { Rake::Task['ownership:preflight'].reenable }
+
+  def run
+    Rake::Task['ownership:preflight'].invoke
+  end
+
+  # A principal the backfill created from an email alone: no external_uid, so no
+  # JWT can ever resolve to it. Records in its personal organization are
+  # unreachable once the email rule stops granting access.
+  def unreachable_owner
+    principal = Principal.legacy_for_email('never-logged-in@example.com')
+    Organization.personal_for!(principal)
+  end
+
+  # The case that actually happened: staging had 2,680 owned records and no
+  # organizations at all, and the first version of this audit reported PASS,
+  # because its join on owner_organization_id could not see a single one of
+  # them. A vacuous pass is worse than no check.
+  it 'fails loudly on a database that was never backfilled' do
+    create(:plant, :private, owned_by: 'someone@example.com')
+
+    expect { run }
+      .to raise_error(SystemExit)
+      .and output(/NOT READY: 1 records have no owner organization at all/).to_stdout
+  end
+
+  it 'passes when every personally-owned record has a resolvable owner' do
+    principal = create(:principal) # a real IdP identity: external_uid present
+    org = Organization.personal_for!(principal)
+    create(:plant, :private, owned_by: principal.email,
+                             owner_organization_id: org.id, source_organization_id: org.id)
+
+    expect { run }.to output(/PASS: every personally-owned record is reachable/).to_stdout
+  end
+
+  it 'fails and names the owner when a record is owned by an unresolvable principal' do
+    org = unreachable_owner
+    create(:plant, :private, owned_by: 'never-logged-in@example.com',
+                             owner_organization_id: org.id, source_organization_id: org.id)
+
+    expect { run }
+      .to raise_error(SystemExit)
+      .and output(/never-logged-in@example\.com: 1 records/).to_stdout
+  end
+
+  it 'does not flag records owned by a real organization' do
+    org = create(:organization, :real)
+    create(:plant, :private, owner_organization_id: org.id, source_organization_id: org.id)
+
+    expect { run }.to output(/owned by a REAL organization.*: 1/m).to_stdout
+  end
+
+  it 'counts across every owned model, not just plants' do
+    org = unreachable_owner
+    %i[plant variety specimen location category].each do |kind|
+      create(kind, owner_organization_id: org.id, source_organization_id: org.id,
+                   owned_by: 'never-logged-in@example.com')
+    end
+    # Factories build associated records (a specimen brings a plant and a
+    # variety) without ownership, and the un-backfilled check runs first and
+    # would abort before the per-model counting this example is about. Give
+    # those incidental rows the same owner so the subject under test is the
+    # counting, not the setup.
+    [Plant, Variety, Specimen, Location, Category].each do |model|
+      model.where(owner_organization_id: nil)
+           .update_all(owner_organization_id: org.id, source_organization_id: org.id)
+    end
+
+    expect { run }
+      .to raise_error(SystemExit)
+      .and output(/"plants" => \d+.*"varieties" => \d+.*"specimens" => \d+.*"locations" => \d+.*"categories" => \d+/m)
+      .to_stdout
+  end
+end


### PR DESCRIPTION
Two read-mostly ops tasks, shipping **ahead of** the S7 change they exist to gate. No migration, no policy change, nothing that alters a single request.

Ships separately on purpose: a one-off ECS task runs the image that is **currently deployed**, so tooling meant to answer questions *about* production has to be deployed to production *first*. That's the trap that made the first trust audit fail.

## `ownership:preflight`

`ownership:verify` checks the three ownership columns for NULLs. It does not check whether a non-NULL `owner_organization_id` is **reachable** — and that is the one thing S7 can break silently.

After S7, your personal organization is resolved from the JWT by `(identity_issuer, external_uid)`, not by email. A record owned by a personal org whose principal has no `external_uid` is unreachable by *everyone*: no token can resolve to it. The S6 divergence soak can't cover this either — it only observed users who made requests during the window, and the users most likely to be affected are the ones who haven't logged in.

Already caught something real: its first run against staging returned **PASS**, which was worthless — the join on `owner_organization_id` couldn't see staging's 2,680 NULL rows. It now counts NULLs first and reports `NOT_READY_NOT_BACKFILLED`. The spec builds that exact case.

## `ownership:staging_rehearsal`

Staging was never backfilled (~2,680 owned records, zero organizations), so the NOT NULL migration can't apply there and nothing downstream can be tested. The real backfill needs the IdP export, which is PII and deliberately not retained, so this synthesizes a mapping from staging's own data: **fake uids, real shape**. That's sufficient for a rehearsal because nothing logs into staging with a production token.

Fabricating identities is only ever acceptable in staging, so it is **guarded twice, neither sufficient alone**:

1. the workflow refuses the action unless `environment=staging`;
2. `StagingRehearsalMapping.guard_staging!` refuses any database but `Plant_API_staging`, by asking the **live connection** — so it holds even when invoked by hand with the wrong credentials.

It also inherits the existing `RUN-REAL-BACKFILL` confirmation, because it writes what the real backfill writes. Being staging-only is a reason for fewer consequences, not fewer gates.

## Note for the reviewer

An earlier draft shipped both base64-inlined into the workflow to avoid needing a deploy. Deploying the tooling first is simply better: reviewable in the diff, testable in CI, and not indistinguishable from obfuscation.

`1932 examples, 0 failures`. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145DvgNvxaMQSi9wxDtAytt