### PR TITLE
Repair the ownership the S7 pre-flight found unreachable

### DIFF
--- a/.github/workflows/ops-ownership-backfill.yml
+++ b/.github/workflows/ops-ownership-backfill.yml
@@ -63,6 +63,7 @@ on:
           - report
           - verify
           - preflight
+          - repair_unreachable
           - backfill_staging_rehearsal
           - backfill
       dry_run:
@@ -110,7 +111,7 @@ jobs:
       # same confirmation. The rehearsal being staging-only is a reason for
       # fewer consequences, not for fewer gates.
       - name: Fail if real backfill requested without confirmation
-        if: (inputs.action == 'backfill' || inputs.action == 'backfill_staging_rehearsal') && inputs.dry_run == false
+        if: (inputs.action == 'backfill' || inputs.action == 'backfill_staging_rehearsal' || inputs.action == 'repair_unreachable') && inputs.dry_run == false
         run: |
           if [ "${{ inputs.confirm_real_run }}" != "RUN-REAL-BACKFILL" ]; then
             echo "::error::SAFETY GATE: a writing backfill with dry_run=FALSE requires"
@@ -185,6 +186,21 @@ jobs:
               # to gate, so the audit can answer for production BEFORE the risky
               # change is anywhere near it.
               RAKE_CMD="bundle exec rake ownership:preflight"
+              ;;
+            repair_unreachable)
+              # Repairs what preflight found. The affected addresses and uids
+              # are PERSONAL DATA and this repository is PUBLIC, so they are
+              # never in the code -- they come from a private mapping object at
+              # runtime, exactly as ownership:backfill takes its MAPPING.
+              if [ -z "${{ inputs.mapping_s3_uri }}" ]; then
+                echo "::error::action=repair_unreachable requires mapping_s3_uri (private s3:// object)."
+                exit 1
+              fi
+              DR_FLAG="DRY_RUN=1"
+              if [ "$DRY_RUN" = "false" ]; then
+                DR_FLAG="DRY_RUN=0"
+              fi
+              RAKE_CMD="bundle exec rake ownership:repair_unreachable REPAIR_MAPPING=${{ inputs.mapping_s3_uri }} ${DR_FLAG}"
               ;;
             backfill_staging_rehearsal)
               # Fills ownership on STAGING so S7 can be rehearsed against

--- a/lib/ownership_repair.rb
+++ b/lib/ownership_repair.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Repairs records that `rake ownership:preflight` reports as unreachable, so S7
+# can ship without silently taking records away from people.
+#
+# WHY RECORDS BECOME UNREACHABLE
+#
+# The S3 backfill routed owners missing from the IdP identity export down its
+# legacy-email path, creating principals with external_uid NULL. A JWT resolves
+# a principal by (identity_issuer, external_uid), never by email, so nothing can
+# ever resolve to one of those -- their personal organizations are unreachable
+# by definition. Today the legacy email rule papers over this; S7 removes it.
+#
+# The export selects User.where.not(uid: nil), which is exactly how such owners
+# get missed.
+#
+# THE AFFECTED IDENTITIES ARE NOT IN THIS REPOSITORY
+#
+# This repository is PUBLIC. The addresses being repaired, and the IdP uids they
+# map to, are personal data and are supplied at runtime from a private source --
+# the same treatment ownership:backfill gives its MAPPING file (rollout.md:
+# "The export JSON contains PII ... never SCP to a laptop, email, or a public
+# bucket"). Do not inline them here, in a spec, or in a commit message.
+#
+# Config shape (JSON), from a private s3:// object or a local path:
+#
+#   {
+#     "link":  [ { "old_email": "...", "uid": "...", "email": "..." } ],
+#     "purge": [ "..." ]
+#   }
+#
+# CASE SENSITIVITY MATTERS
+#
+# IdP uids are mixed case. Postgres string comparison is case-sensitive and
+# Principal.resolve! matches external_uid exactly, so a uid stored in the wrong
+# case would resolve to nothing and recreate the very bug being fixed. Values
+# are used exactly as supplied and must never be normalized.
+#
+# rubocop:disable Metrics/ModuleLength -- the operations performed on a repair
+# config stay in one file on purpose. This deletes production records, and a
+# reviewer should be able to follow exactly what happens to each entry without
+# chasing it across files.
+module OwnershipRepair
+  ECHOCOMMUNITY_ISSUER = 'https://www.echocommunity.org'
+  LEGACY_ISSUER = 'legacy-email'
+
+  # Deletion order is forced by the associations: a Specimen destroys its own
+  # life-cycle events and images, but Location has
+  # `has_many :life_cycle_events, dependent: :restrict_with_error`, and Plant
+  # restricts on both varieties and specimens. So specimens have to go first, or
+  # their locations refuse to be deleted.
+  #
+  # Names, not constants: this file is required from a rake task at boot, before
+  # the autoloader can resolve models. Resolved on use instead.
+  PURGE_ORDER = %w[Specimen Location Variety Plant].freeze
+
+  Config = Struct.new(:link, :purge, keyword_init: true)
+
+  module_function
+
+  def load_config(path)
+    raw = JSON.parse(File.read(path))
+    link = Array(raw['link']).map do |entry|
+      %w[old_email uid email].each do |key|
+        raise ArgumentError, "link entry missing '#{key}'" if entry[key].blank?
+      end
+      entry
+    end
+    Config.new(link: link, purge: Array(raw['purge']))
+  rescue JSON::ParserError => e
+    raise ArgumentError, "repair config is not valid JSON: #{e.message}"
+  end
+
+  def run!(config, dry_run: true)
+    report = { link: [], purge: [], refused: [], linked: 0, purged: Hash.new(0) }
+    config.link.each { |entry| apply_link!(entry, dry_run, report) }
+    config.purge.each { |email| apply_purge!(email, dry_run, report) }
+    report
+  end
+
+  def purge_models
+    PURGE_ORDER.map(&:constantize)
+  end
+
+  # The unreachable personal organization for an address, or nil.
+  def legacy_org_for(email)
+    principal = Principal.find_by(identity_issuer: LEGACY_ISSUER, email: email, external_uid: nil)
+    return nil if principal.nil?
+
+    Organization.find_by(principal_id: principal.id, kind: 'personal')
+  end
+
+  def owned_counts(org)
+    purge_models.index_with { |model| model.where(owner_organization_id: org.id).count }
+  end
+
+  # Adopting the uid keeps the existing personal organization, so every record it
+  # owns becomes reachable without a single row being rewritten. Only when the
+  # person has ALREADY signed in under their real address -- which created a
+  # second principal and a second personal org -- do the records have to move.
+  def link_plan(old_email, uid)
+    legacy_org = legacy_org_for(old_email)
+    return { action: :nothing_to_do } if legacy_org.nil?
+
+    existing = Principal.find_by(identity_issuer: ECHOCOMMUNITY_ISSUER, external_uid: uid)
+    if existing
+      { action: :repoint, from_org: legacy_org, principal: existing,
+        to_org: Organization.find_by(principal_id: existing.id, kind: 'personal') }
+    else
+      { action: :adopt, principal: Principal.find(legacy_org.principal_id), org: legacy_org }
+    end
+  end
+
+  # Reports are written with a redacted label rather than the address, because
+  # they are printed into CI logs that are public for this repository.
+  def label(email)
+    local, domain = email.to_s.split('@')
+    "#{local.to_s[0, 2]}***@#{domain}"
+  end
+
+  def apply_link!(entry, dry_run, report)
+    plan = link_plan(entry['old_email'], entry['uid'])
+    case plan[:action]
+    when :nothing_to_do
+      report[:link] << "#{label(entry['old_email'])}: no unreachable personal organization (already repaired?)"
+    when :adopt
+      adopt!(entry, plan, dry_run, report)
+    when :repoint
+      repoint!(entry, plan, dry_run, report)
+    end
+  end
+
+  def adopt!(entry, plan, dry_run, report)
+    counts = owned_counts(plan[:org]).transform_keys(&:name)
+    report[:link] << "#{label(entry['old_email'])} ADOPT uid onto principal " \
+                     "#{plan[:principal].id}; becomes reachable: #{counts.inspect}"
+    return if dry_run
+
+    plan[:principal].update!(identity_issuer: ECHOCOMMUNITY_ISSUER,
+                             external_uid: entry['uid'], email: entry['email'])
+    report[:linked] += 1
+  end
+
+  def repoint!(entry, plan, dry_run, report)
+    report[:link] << repoint_message(entry, plan)
+    if plan[:to_org].nil?
+      report[:refused] << "#{label(entry['old_email'])}: principal #{plan[:principal].id} has no personal organization"
+      return
+    end
+    return if dry_run
+
+    move_records!(plan[:from_org], plan[:to_org])
+    report[:linked] += 1
+  end
+
+  def repoint_message(entry, plan)
+    counts = owned_counts(plan[:from_org]).transform_keys(&:name)
+    "#{label(entry['old_email'])} REPOINT to org #{plan[:to_org]&.id}; records to move: #{counts.inspect}"
+  end
+
+  def move_records!(from_org, to_org)
+    purge_models.each do |model|
+      model.where(owner_organization_id: from_org.id)
+           .update_all(owner_organization_id: to_org.id)
+    end
+  end
+
+  def apply_purge!(email, dry_run, report)
+    org = legacy_org_for(email)
+    if org.nil?
+      report[:purge] << "#{label(email)}: no unreachable personal organization (already purged?)"
+      return
+    end
+
+    report[:purge] << "#{label(email)}: #{owned_counts(org).transform_keys(&:name).inspect}"
+    destroy_owned!(org, email, report) unless dry_run
+  end
+
+  # A restricted delete is reported, never forced: if someone else's event still
+  # points at one of these locations, that is a fact to look at.
+  def destroy_owned!(org, email, report)
+    purge_models.each do |model|
+      model.where(owner_organization_id: org.id).find_each { |r| destroy_one!(r, model, email, report) }
+    end
+  end
+
+  def destroy_one!(record, model, email, report)
+    if record.destroy
+      report[:purged][model.name] += 1
+    else
+      report[:refused] << "#{model.name} #{record.id} (#{label(email)}): " \
+                          "#{record.errors.full_messages.join('; ')}"
+    end
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/lib/tasks/ownership_repair.rake
+++ b/lib/tasks/ownership_repair.rake
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ownership_repair')
+
+# Repairs the records `ownership:preflight` reports as unreachable. See
+# lib/ownership_repair.rb for what is being repaired and why.
+#
+#   REPAIR_MAPPING  local path OR s3:// URI to the repair config JSON
+#   DRY_RUN         1 (default) reports the plan and writes nothing
+#
+# The config carries personal data and is supplied at runtime from a private
+# source; it is deliberately not in this repository, which is public. Same
+# treatment as ownership:backfill's MAPPING (rollout.md).
+def print_repair_report(report, dry_run)
+  puts "\nLINK -- give these records an owner who can actually sign in"
+  report[:link].each { |line| puts "  #{line}" }
+
+  puts "\nPURGE -- confirmed disposable by the account holder"
+  report[:purge].each { |line| puts "  #{line}" }
+
+  puts "\n#{'=' * 60}"
+  if dry_run
+    puts 'DRY RUN complete. Nothing was written. Re-run with DRY_RUN=0 to apply.'
+  else
+    puts "Owners linked: #{report[:linked]}"
+    puts "Records purged: #{report[:purged].inspect}"
+  end
+
+  if report[:refused].any?
+    puts "\nREFUSED (#{report[:refused].size}) -- left untouched on purpose, look at these:"
+    report[:refused].each { |line| puts "  #{line}" }
+  end
+  puts 'Addresses are shown redacted; this log is public. Re-run ownership:preflight to confirm.'
+end
+
+namespace :ownership do
+  desc 'Repair unreachable ownership from a private REPAIR_MAPPING config (DRY_RUN=1 default)'
+  task repair_unreachable: :environment do
+    mapping_env = ENV.fetch('REPAIR_MAPPING', nil)
+    abort 'ERROR: REPAIR_MAPPING env var is required (local path or s3:// URI)' if mapping_env.blank?
+
+    dry_run = ENV.fetch('DRY_RUN', '1') != '0'
+    puts 'ownership:repair_unreachable'
+    puts "MODE #{dry_run ? 'DRY RUN -- nothing will be written' : 'WRITING'}"
+    puts '=' * 60
+
+    report = with_mapping_path(mapping_env) do |path|
+      config = OwnershipRepair.load_config(path)
+      puts "Config: #{config.link.size} to link, #{config.purge.size} to purge"
+      OwnershipRepair.run!(config, dry_run: dry_run)
+    end
+
+    print_repair_report(report, dry_run)
+  end
+end

--- a/lib/tasks/ownership_repair.rake
+++ b/lib/tasks/ownership_repair.rake
@@ -11,13 +11,12 @@ require Rails.root.join('lib/ownership_repair')
 # The config carries personal data and is supplied at runtime from a private
 # source; it is deliberately not in this repository, which is public. Same
 # treatment as ownership:backfill's MAPPING (rollout.md).
-def print_repair_report(report, dry_run)
-  puts "\nLINK -- give these records an owner who can actually sign in"
-  report[:link].each { |line| puts "  #{line}" }
+def print_repair_section(title, lines)
+  puts "\n#{title}"
+  lines.each { |line| puts "  #{line}" }
+end
 
-  puts "\nPURGE -- confirmed disposable by the account holder"
-  report[:purge].each { |line| puts "  #{line}" }
-
+def print_repair_outcome(report, dry_run)
   puts "\n#{'=' * 60}"
   if dry_run
     puts 'DRY RUN complete. Nothing was written. Re-run with DRY_RUN=0 to apply.'
@@ -25,10 +24,16 @@ def print_repair_report(report, dry_run)
     puts "Owners linked: #{report[:linked]}"
     puts "Records purged: #{report[:purged].inspect}"
   end
+end
+
+def print_repair_report(report, dry_run)
+  print_repair_section('LINK -- give these records an owner who can actually sign in', report[:link])
+  print_repair_section('PURGE -- confirmed disposable by the account holder', report[:purge])
+  print_repair_outcome(report, dry_run)
 
   if report[:refused].any?
-    puts "\nREFUSED (#{report[:refused].size}) -- left untouched on purpose, look at these:"
-    report[:refused].each { |line| puts "  #{line}" }
+    print_repair_section("REFUSED (#{report[:refused].size}) -- left untouched on purpose, look at these:",
+                         report[:refused])
   end
   puts 'Addresses are shown redacted; this log is public. Re-run ownership:preflight to confirm.'
 end

--- a/spec/tasks/ownership_repair_spec.rb
+++ b/spec/tasks/ownership_repair_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require 'tempfile'
+require Rails.root.join('lib/ownership_repair')
+
+# This task deletes production records. The two things that must be true before
+# anyone runs it: the dry run writes nothing, and the deletion order respects
+# the restrict_with_error associations rather than blowing past them.
+RSpec.describe 'ownership:repair_unreachable', type: :task do
+  before(:all) do
+    Rake::Task.clear
+    Rails.application.load_tasks
+  end
+
+  before { Rake::Task['ownership:repair_unreachable'].reenable }
+
+  # Config is written to a tempfile, never committed: the real one carries
+  # personal data and this repository is public.
+  def run(dry_run: true, link: [link_entry], purge: [purge_email])
+    file = Tempfile.new(['repair', '.json'])
+    file.write(JSON.generate('link' => link, 'purge' => purge))
+    file.flush
+    ENV['DRY_RUN'] = dry_run ? '1' : '0'
+    ENV['REPAIR_MAPPING'] = file.path
+    Rake::Task['ownership:repair_unreachable'].invoke
+  ensure
+    ENV.delete('DRY_RUN')
+    ENV.delete('REPAIR_MAPPING')
+    file&.close
+    file&.unlink
+  end
+
+  # The shape the backfill left behind: a principal with no external_uid, so no
+  # JWT can ever resolve to it, owning records through its personal org.
+  def unreachable_owner(email)
+    principal = Principal.create!(identity_issuer: OwnershipRepair::LEGACY_ISSUER,
+                                  email: email, external_uid: nil, kind: 'human')
+    Organization.personal_for!(principal)
+  end
+
+  # Fictional values. The real ones live in a private config supplied at runtime.
+  let(:purge_email) { 'purge-me@example.test' }
+  let(:link_email)  { 'old-address@example.test' }
+  # Mixed case on purpose: uid comparison is case-sensitive.
+  let(:link_uid)    { 'AB12CD34-5678-49AB-8CDE-F01234567890' }
+  let(:link_target) { { uid: link_uid, email: 'new-address@example.test' } }
+  let(:link_entry)  { { 'old_email' => link_email, 'uid' => link_uid, 'email' => link_target[:email] } }
+
+  describe 'the dry run' do
+    it 'writes nothing at all' do
+      org = unreachable_owner(purge_email)
+      create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+      link_org = unreachable_owner(link_email)
+      principal_before = Principal.find(link_org.principal_id).attributes
+
+      expect { run(dry_run: true) }.to output(/DRY RUN complete/).to_stdout
+      expect(Plant.where(owner_organization_id: org.id).count).to eq 1
+      expect(Principal.find(link_org.principal_id).attributes).to eq principal_before
+    end
+  end
+
+  describe 'linking' do
+    it 'adopts the real uid onto the existing principal, so no record has to move' do
+      org = unreachable_owner(link_email)
+      plant = create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+
+      run(dry_run: false)
+
+      principal = Principal.find(org.principal_id)
+      expect(principal.external_uid).to eq link_target[:uid]
+      expect(principal.identity_issuer).to eq OwnershipRepair::ECHOCOMMUNITY_ISSUER
+      expect(principal.email).to eq link_target[:email]
+      # The record never moved -- its organization simply became reachable.
+      expect(plant.reload.owner_organization_id).to eq org.id
+    end
+
+    it 'preserves uid case exactly, since resolution is a case-sensitive match' do
+      expect(link_uid).not_to eq link_uid.downcase
+
+      org = unreachable_owner(link_email)
+      run(dry_run: false)
+      expect(Principal.find(org.principal_id).external_uid).to eq link_target[:uid]
+    end
+
+    it 'repoints records instead when the person already signed in under the real address' do
+      legacy_org = unreachable_owner(link_email)
+      plant = create(:plant, owner_organization_id: legacy_org.id, source_organization_id: legacy_org.id)
+      real = Principal.create!(identity_issuer: OwnershipRepair::ECHOCOMMUNITY_ISSUER,
+                               external_uid: link_target[:uid], email: link_target[:email], kind: 'human')
+      real_org = Organization.personal_for!(real)
+
+      run(dry_run: false)
+
+      expect(plant.reload.owner_organization_id).to eq real_org.id
+    end
+  end
+
+  describe 'purging' do
+    it 'deletes the records owned by a confirmed-disposable address' do
+      org = unreachable_owner(purge_email)
+      create(:location, owner_organization_id: org.id, source_organization_id: org.id)
+
+      expect { run(dry_run: false) }.to change(Location, :count).by(-1)
+    end
+
+    it 'destroys a specimen before its location, so the location is not restricted' do
+      org = unreachable_owner(purge_email)
+      location = create(:location, owner_organization_id: org.id, source_organization_id: org.id)
+      specimen = create(:specimen, owner_organization_id: org.id, source_organization_id: org.id)
+      create(:planting_event, specimen: specimen, location: location)
+
+      run(dry_run: false)
+
+      expect(Specimen.where(id: specimen.id)).to be_empty
+      expect(Location.where(id: location.id)).to be_empty
+    end
+
+    it 'reports a refusal rather than forcing it when something else still references the record' do
+      org = unreachable_owner(purge_email)
+      location = create(:location, owner_organization_id: org.id, source_organization_id: org.id)
+      # An event belonging to somebody else's specimen still points at it.
+      create(:planting_event, specimen: create(:specimen), location: location)
+
+      expect { run(dry_run: false) }.to output(/REFUSED/).to_stdout
+      expect(Location.where(id: location.id)).to be_present
+    end
+  end
+end


### PR DESCRIPTION
**Redacted.** An earlier version of this description contained personal email addresses and IdP identifiers. This repository is public; that content has been removed and the branch rewritten. See the private ops channel for the affected identities.

## Why

`ownership:preflight` against production returned FAIL: 336 records owned by principals with `external_uid` NULL. A JWT resolves a principal by `(identity_issuer, external_uid)` and never by email, so nothing can ever resolve to one of those. The legacy email rule papers over it today; S7 removes it.

Those principals came from the backfill's legacy-email path, which handles owners missing from the identity export — and the export selects `User.where.not(uid: nil)`. That is how they were missed.

## How

The affected identities are supplied at runtime from a private source, exactly as `ownership:backfill` takes its mapping — they are deliberately **not** in this repository.

Linking adopts the real uid onto the existing legacy principal, so its personal organization becomes reachable and no record is rewritten. Only if the person has already signed in under their real address does it repoint. Both paths are tested.

Two details that would each have broken this silently:

- **uid case is load-bearing.** Postgres comparison is case-sensitive and `resolve!` matches `external_uid` exactly, so a normalized uid would resolve to nothing and recreate the very bug being fixed.
- **Deletion order is forced by the associations.** `Location` has `dependent: :restrict_with_error` on `life_cycle_events` and `Plant` restricts on varieties and specimens, so specimens must go first. A refusal is reported and left alone, never forced.

`DRY_RUN=1` by default, and the dry run is asserted to write nothing. The ops workflow action inherits the existing `RUN-REAL-BACKFILL` confirmation.

Branched from the last commit before S7, so this can run against production while S7 stays off it.