### PR TITLE
Add plants:import for the ECHOcommunity plant migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,6 +138,3 @@ Style/SlicingWithRange:
     Enabled: true
 Style/StringConcatenation:
     Enabled: true
-Metrics/ClassLength:
-    Exclude:
-        - 'lib/ec_plant_importer.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,3 +138,6 @@ Style/SlicingWithRange:
     Enabled: true
 Style/StringConcatenation:
     Enabled: true
+Metrics/ClassLength:
+    Exclude:
+        - 'lib/ec_plant_importer.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/BlockLength:
         - 'db/schema.rb'
         - 'db/migrate/*.rb'
         - 'lib/tasks/ownership.rake'
+        - 'lib/tasks/plant_import.rake'
 Metrics/MethodLength:
     Exclude:
         - 'db/migrate/*.rb'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+The ECHO Open Plant Database: Rails 8.1 / Ruby 3.4 (YJIT), PostgreSQL, **GraphQL-only** — the only routes are `POST /graphql` and healthchecks; there is no HTML UI. Deployed on ECS Fargate via Terraform (`infra/`); staging (plant-api-staging.echocommunity.org) auto-deploys from CI, production (plant-api.echocommunity.org) is behind a manual gate in the Deploy workflow. Default branch: `master`.
+
+Plant administration is **not** in this repo — it is a separate SPA (its own repo) at plant-admin.echocommunity.org, talking to this API over GraphQL.
+
+Workspace note: when this repo is checked out inside the plant-data-migration workspace (`../CLAUDE.md`, `../project_prompt.md`), those files define the cross-system migration context and the production-safety rules that govern all work here.
+
+## Commands
+
+```bash
+# All dev/test DB config points at host "db" (the docker-compose service name):
+# run inside the container (docker-compose exec web ...) or resolve "db" yourself.
+# docker-compose requires a .env file (not committed) — SANDBOX=true is the key entry.
+docker-compose up                            # Postgres + web on :3000 (+ pgadmin :3080, mailcatcher :1080)
+
+bundle exec rails db:create db:schema:load   # loads db/structure.sql
+SANDBOX=true SANDBOX_TRUST_LEVEL=10 bundle exec rspec   # all tests (mirrors CI env)
+bundle exec rspec spec/models/plant_spec.rb:42          # single test
+bundle exec rubocop
+bundle exec rails graphql:schema:dump        # regenerate schema.graphql after GraphQL changes
+```
+
+## Key facts
+
+- **`db/structure.sql` is the authoritative schema** (`schema_format = :sql`). `db/schema.rb` exists but is frozen at 2020 and badly stale — never trust it.
+- **CI diff-gates `schema.graphql`**: any change to GraphQL types/mutations/resolvers must be followed by `rails graphql:schema:dump`, with the regenerated snapshot committed, or CI fails.
+- Data model: `Plant` → `Variety` → `Specimen`, plus lookup tables (antinutrients, tolerances, growth habits, categories) linked through join models; UUID primary keys throughout; PaperTrail version history on records.
+- i18n via Mobility (JSONB `translations` column per table), **pinned at 1.2.9** — the Gemfile comment documents a container-backend regression; don't bump without running `spec/models/mobility_compat_spec.rb`.
+- **Auth: the API verifies but never issues JWTs** (RS256, `Authorization: Token ...`); tokens come from ECHOcommunity's Doorkeeper IdP. There is no users table — `User` is a plain Ruby object hydrated from the JWT (uid, email, trust_levels). Authorization is Pundit policies + a trust-level ladder + an organization/ownership layer.
+- `SANDBOX=true` bypasses JWT for local dev and tests (fixed `sandbox@sandbox.com` user; tune with `SANDBOX_TRUST_LEVEL` — 2 = write, >8 = admin, >9 = super-admin — and `SANDBOX_ORGS`; see `docs/sandbox-mode.md`).
+
+## Docs to read before deep work
+
+- `docs/MODERNIZATION-2026-07.md` — the July 2026 EB→ECS / Rails 6→8.1 / admin-rollout overhaul; recent history and hard-won operational gotchas.
+- `docs/authorization-trust-levels.md` — the trust-level ladder.
+- `docs/ownership-current-state.md` and `docs/ownership-redesign/{design,discovery,rollout}.md` — the accepted organizations/ownership redesign (IdP-authoritative orgs, membership via JWT claims).
+- `infra/README.md` — ECS/Terraform layout; shared ALB with ECHOcommunity, listener-rule warnings.

--- a/app/services/source_synchronizer.rb
+++ b/app/services/source_synchronizer.rb
@@ -167,7 +167,7 @@ class SourceSynchronizer
   # rubocop:disable Metrics/MethodLength
   def compare_and_sync(record, incoming_attrs, src_at, report)
     base  = base_attrs(record)
-    local = record.attributes.slice(*@source_attributes)
+    local = local_attrs(record)
 
     local_digest    = canonical_digest(local)
     incoming_digest = canonical_digest(incoming_attrs)
@@ -245,6 +245,27 @@ class SourceSynchronizer
   end
   # rubocop:enable Metrics/MethodLength
 
+  # Local state for the source-managed attributes.
+  #
+  # Deliberately NOT record.attributes.slice(*@source_attributes). Mobility is
+  # configured with `backend :container` and without the `attribute_methods`
+  # plugin (config/initializers/mobility.rb), so translated attributes
+  # (description, uses, cultivation, ...) live inside the `translations` jsonb
+  # and never appear in #attributes. Slicing there yields {} for them, so local
+  # reads as permanently different from the stored snapshot: an unchanged
+  # re-sync is scored `locally_modified` and a genuine upstream edit is silently
+  # dropped rather than applied. Reading through the public reader treats
+  # column-backed and translated attributes identically.
+  #
+  # Note on fallbacks: the Mobility `fallbacks` plugin means reading a missing
+  # locale returns the :en value. Sync writes and reads within the same locale,
+  # so the comparison stays symmetric.
+  def local_attrs(record)
+    @source_attributes.each_with_object({}) do |attr, acc|
+      acc[attr] = record.public_send(attr) if record.respond_to?(attr)
+    end
+  end
+
   # base = last accepted source snapshot, sliced to source_attributes
   def base_attrs(record)
     snap = record.source_snapshot
@@ -287,7 +308,7 @@ class SourceSynchronizer
   end
 
   def handle_source_deletion(record, report)
-    local = record.attributes.slice(*@source_attributes)
+    local = local_attrs(record)
 
     existing = SyncConflict.where(
       syncable: record,

--- a/lib/ec_plant_importer.rb
+++ b/lib/ec_plant_importer.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Imports plants exported from ECHOcommunity during the plant-data ownership
+# migration.
+#
+# Consumes the same JSON shape as db/seeds/Plants.json, so the export tooling
+# targets a format this application already understands. Writes go through the
+# model layer, never raw SQL, so Mobility translations, the visibility trio and
+# PaperTrail all behave normally (migration decision D-016).
+#
+# Idempotent: a record whose uuid already exists is skipped, never overwritten.
+# Bringing an existing record up to date is reconciliation, a separate concern
+# with conflict handling.
+class EcPlantImporter
+  Result = Struct.new(:created, :skipped, :failed, :errors, keyword_init: true)
+
+  RANGE_FIELDS = %w[
+    n_accumulation_range biomass_production_range optimal_temperature_range
+    optimal_rainfall_range optimal_altitude_range seasonality_days_range ph_range
+  ].freeze
+
+  SCALAR_FIELDS = %w[
+    scientific_name family_names has_edible_green_leaves
+    has_edible_immature_fruit has_edible_mature_fruit can_be_used_for_fodder
+    early_growth_phase life_cycle
+  ].freeze
+
+  def initialize(organization:, principal:, owner_email:, apply: false)
+    @organization = organization
+    @principal = principal
+    @owner_email = owner_email
+    @apply = apply
+  end
+
+  def import(records)
+    result = Result.new(created: 0, skipped: 0, failed: 0, errors: [])
+    records.each { |row| import_row(row, result) }
+    result
+  end
+
+  # "25..32" -> 25..32, "5.0..7.0" -> 5.0..7.0. The seed task used eval for
+  # this; parsing avoids executing data.
+  def self.parse_range(str)
+    return nil if str.blank?
+
+    lo, hi = str.split('..', 2)
+    return nil if hi.nil?
+
+    return Range.new(lo.to_f, hi.to_f) if lo.include?('.') || hi.include?('.')
+
+    Range.new(lo.to_i, hi.to_i)
+  end
+
+  private
+
+  def import_row(row, result)
+    return result.skipped += 1 if Plant.unscoped.exists?(id: row['uuid'])
+    return result.created += 1 unless @apply
+
+    persist(row)
+    result.created += 1
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "#{row['uuid']} (#{row['scientific_name']}): #{e.class}: #{e.message}"
+  end
+
+  def persist(row)
+    ActiveRecord::Base.transaction do
+      plant = build_plant(row)
+      plant.save!
+      create_common_names(plant, row)
+    end
+  end
+
+  def build_plant(row)
+    plant = Plant.new(base_attributes(row))
+    apply_translations(plant, row)
+    plant
+  end
+
+  def base_attributes(row)
+    attrs = {
+      id: row['uuid'], owned_by: @owner_email, created_by: @owner_email,
+      visibility: :public, owner_organization_id: @organization.id,
+      source_organization_id: @organization.id,
+      created_by_principal_id: @principal.id
+    }
+    SCALAR_FIELDS.each { |f| attrs[f.to_sym] = row[f] unless row[f].nil? }
+    attrs.merge(range_attributes(row))
+  end
+
+  # Assign every range unconditionally, nil included. These columns carry
+  # defaults that assert facts nobody measured -- ph_range '[0.0,14.0]',
+  # optimal_temperature_range '[0,61)', n_accumulation_range '[0,1)',
+  # biomass_production_range '[0.0,0.0]', rainfall and altitude '[0,)'.
+  # Omitting an absent range would record "tolerates pH 0-14" rather than
+  # "unknown", which is how the 2020 export left 174 of 322 plants claiming
+  # exactly that.
+  def range_attributes(row)
+    RANGE_FIELDS.index_with { |f| self.class.parse_range(row[f]) }
+                .transform_keys(&:to_sym)
+  end
+
+  def apply_translations(plant, row)
+    (row['translations'] || {}).each_value do |values|
+      values = values.dup
+      locale = values.delete('locale')
+      values.delete('primary_common_name') # belongs to CommonName, not the plant
+      next if locale.blank?
+
+      Mobility.with_locale(locale) { assign_translated(plant, values) }
+    end
+  end
+
+  def assign_translated(plant, values)
+    values.each do |key, value|
+      next if value.blank?
+
+      plant.public_send("#{key}=", value) if plant.respond_to?("#{key}=")
+    end
+  end
+
+  # The exporter records ECHOcommunity's display title per locale as
+  # primary_common_name; whichever common name matches it becomes the primary
+  # for that language (migration decision D-026).
+  def create_common_names(plant, row)
+    primaries = primary_names_by_locale(row)
+    (row['common_names'] || {}).each do |language, names|
+      names.each do |cn|
+        next if cn['name'].blank?
+
+        CommonName.create!(
+          plant: plant, language: language, name: cn['name'],
+          location: cn['location'],
+          primary: primaries[language.to_s.downcase] == cn['name'].to_s.downcase
+        )
+      end
+    end
+  end
+
+  def primary_names_by_locale(row)
+    (row['translations'] || {}).each_with_object({}) do |(_k, values), acc|
+      locale = values['locale']
+      name = values['primary_common_name']
+      acc[locale.to_s.downcase] = name.downcase if locale.present? && name.present?
+    end
+  end
+end

--- a/lib/ec_plant_importer.rb
+++ b/lib/ec_plant_importer.rb
@@ -25,6 +25,11 @@ class EcPlantImporter
     early_growth_phase life_cycle
   ].freeze
 
+  # The export carries ECHOcommunity's status as a visibility, so a draft is
+  # never created public and hidden a moment later. Anything unrecognised is
+  # treated as draft: erring towards invisible is the safe direction.
+  VISIBILITIES = %w[public draft private deleted].freeze
+
   def initialize(organization:, principal:, owner_email:, apply: false)
     @organization = organization
     @principal = principal
@@ -81,7 +86,7 @@ class EcPlantImporter
   def base_attributes(row)
     attrs = {
       id: row['uuid'], owned_by: @owner_email, created_by: @owner_email,
-      visibility: :public, owner_organization_id: @organization.id,
+      visibility: visibility_for(row), owner_organization_id: @organization.id,
       source_organization_id: @organization.id,
       created_by_principal_id: @principal.id
     }
@@ -99,6 +104,11 @@ class EcPlantImporter
   def range_attributes(row)
     RANGE_FIELDS.index_with { |f| self.class.parse_range(row[f]) }
                 .transform_keys(&:to_sym)
+  end
+
+  def visibility_for(row)
+    value = row['visibility'].to_s
+    VISIBILITIES.include?(value) ? value.to_sym : :draft
   end
 
   def apply_translations(plant, row)

--- a/lib/ec_plant_importer.rb
+++ b/lib/ec_plant_importer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'ec_range_parser'
+
 # Imports plants exported from ECHOcommunity during the plant-data ownership
 # migration.
 #
@@ -41,19 +43,6 @@ class EcPlantImporter
     result = Result.new(created: 0, skipped: 0, failed: 0, errors: [])
     records.each { |row| import_row(row, result) }
     result
-  end
-
-  # "25..32" -> 25..32, "5.0..7.0" -> 5.0..7.0. The seed task used eval for
-  # this; parsing avoids executing data.
-  def self.parse_range(str)
-    return nil if str.blank?
-
-    lo, hi = str.split('..', 2)
-    return nil if hi.nil?
-
-    return Range.new(lo.to_f, hi.to_f) if lo.include?('.') || hi.include?('.')
-
-    Range.new(lo.to_i, hi.to_i)
   end
 
   private
@@ -102,7 +91,7 @@ class EcPlantImporter
   # "unknown", which is how the 2020 export left 174 of 322 plants claiming
   # exactly that.
   def range_attributes(row)
-    RANGE_FIELDS.index_with { |f| self.class.parse_range(row[f]) }
+    RANGE_FIELDS.index_with { |f| EcRangeParser.parse(row[f]) }
                 .transform_keys(&:to_sym)
   end
 

--- a/lib/ec_range_parser.rb
+++ b/lib/ec_range_parser.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Parses the "min..max" range strings used by db/seeds/Plants.json and the
+# ECHOcommunity migration export.
+#
+# The seed task used eval for this. Parsing avoids executing data, and keeps
+# the behaviour in one place now that both the importer and its specs rely on
+# it.
+module EcRangeParser
+  module_function
+
+  # "25..32" -> 25..32, "5.0..7.0" -> 5.0..7.0, blank or malformed -> nil.
+  def parse(str)
+    return nil if str.blank?
+
+    low, high = str.split('..', 2)
+    return nil if high.nil?
+
+    return Range.new(low.to_f, high.to_f) if low.include?('.') || high.include?('.')
+
+    Range.new(low.to_i, high.to_i)
+  end
+end

--- a/lib/tasks/plant_import.rake
+++ b/lib/tasks/plant_import.rake
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_plant_importer')
+
+# Thin wrapper: the import logic and its reasoning live in
+# lib/ec_plant_importer.rb, following the pattern of staging_rehearsal.rake.
+#
+#   bin/rails plants:import[tmp/import.json]              # dry run
+#   APPLY=true bin/rails plants:import[tmp/import.json]   # actually write
+#
+# ECHO_ORG_ID selects the owning organization and differs between environments;
+# staging uses StagingRehearsalMapping::ECHO_ORG_ID.
+namespace :plants do
+  desc 'Import ECHOcommunity plants from a seed-format JSON file (dry run unless APPLY=true)'
+  task :import, [:path] => :environment do |_t, args|
+    path = args[:path] or abort 'usage: bin/rails plants:import[path/to/file.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    owner = ENV.fetch('ECHO_OWNER_EMAIL', 'echo@echonet.org')
+    org_id = ENV['ECHO_ORG_ID'].presence or
+      abort 'ECHO_ORG_ID is required (the owning organization for imported plants)'
+
+    org = Organization.find_by(id: org_id) or abort "no organization with id #{org_id}"
+
+    # created_by_principal_id is NOT NULL, and a `real` organization such as
+    # ECHO has no principal of its own -- only `personal` orgs do. Production
+    # attributes its 322 seeded plants to the SERVICE principal for
+    # echo@echonet.org, so default to matching that.
+    principal = if ENV['ECHO_PRINCIPAL_ID'].present?
+                  Principal.find_by(id: ENV['ECHO_PRINCIPAL_ID'])
+                else
+                  Principal.find_by(email: owner, kind: 'service')
+                end
+    principal or abort 'no principal found (set ECHO_PRINCIPAL_ID, or create a ' \
+                       "service principal for #{owner})"
+
+    apply = ENV['APPLY'] == 'true'
+    records = JSON.parse(File.read(path))
+
+    puts "#{apply ? 'IMPORTING' : 'DRY RUN'} #{records.size} plants from #{path}"
+    puts "  owning organization:  #{org.name} (#{org.id})"
+    puts "  owned_by:             #{owner}"
+    puts "  created_by_principal: #{principal.email} (#{principal.kind})"
+    puts
+
+    result = EcPlantImporter.new(organization: org, principal: principal,
+                                 owner_email: owner, apply: apply).import(records)
+
+    puts "  #{apply ? 'created' : 'would create'}: #{result.created}"
+    puts "  skipped (already present): #{result.skipped}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'import finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/services/source_synchronizer_translated_spec.rb
+++ b/spec/services/source_synchronizer_translated_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Verification of the suspected defect recorded as risk R5 in the plant-data
+# ownership migration roadmap.
+#
+# SourceSynchronizer#compare_and_sync reads local state with
+#
+#   local = record.attributes.slice(*@source_attributes)
+#
+# `record.attributes` returns ActiveRecord's column-backed attributes. Mobility
+# is configured with `backend :container` and WITHOUT the `attribute_methods`
+# plugin (config/initializers/mobility.rb), so translated attributes such as
+# `description` live inside the `translations` jsonb and never appear in
+# `attributes`. For a translated source attribute the local side therefore reads
+# as {} on every run.
+#
+# The existing suite never catches this: SOURCE_ATTRS is
+# %w[scientific_name family_names], both real columns, and the one spec that
+# passes %w[description] exercises the invalid-payload path, which returns
+# before compare_and_sync.
+#
+# Predicted consequence: a re-sync of unchanged data is scored as
+# `locally_modified` rather than `synced`, and a genuine upstream change is
+# never applied. Translated fields would silently stop syncing after creation.
+RSpec.describe SourceSynchronizer, 'with a Mobility-translated source attribute' do
+  let(:org)         { create(:organization, :real) }
+  let(:data_source) { create(:data_source, organization: org) }
+  let(:run_id)      { SecureRandom.hex(8) }
+
+  def sync(attrs)
+    SourceSynchronizer.new(
+      data_source: data_source,
+      model: Plant,
+      source_attributes: attrs,
+      run_id: run_id
+    )
+  end
+
+  def row(description:, source_record_id: 'tr-1', source_updated_at: 1.day.ago)
+    {
+      source_record_id: source_record_id,
+      deleted: false,
+      attributes: { 'description' => description },
+      source_updated_at: source_updated_at
+    }
+  end
+
+  it 'confirms the mechanism: a translated attribute is absent from #attributes' do
+    plant = create(:plant, owner_organization_id: org.id, source_organization_id: org.id,
+                           description: 'Some description')
+
+    expect(plant.description).to eq 'Some description'
+    expect(plant.attributes).to have_key('translations')
+    expect(plant.attributes).not_to have_key('description'),
+                                    'if this fails, Mobility now exposes translated attrs and the defect is gone'
+    expect(plant.attributes.slice('description')).to eq({})
+  end
+
+  it 'scores an identical re-run as synced, not locally_modified' do
+    batch = [row(description: 'A stable description')]
+
+    first = sync(%w[description]).apply(batch)
+    expect(first.created).to eq(1), 'expected the first run to create the record'
+
+    second = sync(%w[description]).apply(batch)
+
+    plant = Plant.find_by(source_record_id: 'tr-1')
+    aggregate_failures do
+      expect(second.locally_modified).to eq(0),
+                                         'nobody edited this record, so it must not be scored locally_modified'
+      expect(second.synced).to eq(1)
+      expect(plant.sync_state).to eq 'synced'
+    end
+  end
+
+  it 'applies a genuine upstream change to a translated attribute' do
+    sync(%w[description]).apply([row(description: 'Original text')])
+
+    changed = sync(%w[description]).apply(
+      [row(description: 'Updated upstream text', source_updated_at: 1.hour.ago)]
+    )
+
+    plant = Plant.find_by(source_record_id: 'tr-1')
+    aggregate_failures do
+      expect(changed.applied).to eq(1), 'an upstream edit must reach the record'
+      expect(plant.description).to eq 'Updated upstream text'
+    end
+  end
+end

--- a/spec/tasks/plant_import_spec.rb
+++ b/spec/tasks/plant_import_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe 'plants:import', type: :task do
     Principal.create!(kind: 'service', email: 'echo@echonet.org',
                       identity_issuer: 'spec')
   end
-  let(:task) { Rake::Task['plants:import'].tap(&:reenable) }
+  # A method, not a let: a memoised task cannot be re-invoked within one
+  # example, and rake refuses to run an already-invoked task twice.
+  def task
+    Rake::Task['plants:import'].tap(&:reenable)
+  end
   let(:uuid) { SecureRandom.uuid }
 
   # Hold a reference: a Tempfile deletes itself when garbage collected, and the
@@ -34,6 +38,7 @@ RSpec.describe 'plants:import', type: :task do
   def record(overrides = {})
     {
       'uuid' => uuid,
+      'visibility' => 'public',
       'scientific_name' => 'Adansonia digitata',
       'family_names' => 'Malvaceae',
       'life_cycle' => 'perennial',
@@ -114,6 +119,17 @@ RSpec.describe 'plants:import', type: :task do
 
     expect { run(path) }.not_to change(Plant, :count)
     expect(Plant.find(uuid).scientific_name).to eq 'Edited locally'
+  end
+
+  # ECHOcommunity status arrives as a visibility so a draft is never created
+  # public and hidden a moment later. Anything unrecognised errs to draft.
+  it 'honours the exported visibility, defaulting an unknown value to draft' do
+    run(write_fixture([record({ 'visibility' => 'draft' })]))
+    expect(Plant.find(uuid).visibility).to eq 'draft'
+
+    other = SecureRandom.uuid
+    run(write_fixture([record({ 'uuid' => other, 'visibility' => 'nonsense' })]))
+    expect(Plant.find(other).visibility).to eq 'draft'
   end
 
   it 'writes nothing without APPLY' do

--- a/spec/tasks/plant_import_spec.rb
+++ b/spec/tasks/plant_import_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'plants:import', type: :task do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rake.application.rake_require('tasks/plant_import', [Rails.root.join('lib').to_s])
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:org) { create(:organization, :real) }
+  # A `real` org has no principal of its own; plants are attributed to the
+  # service principal for the owner address, as production does.
+  let!(:service_principal) do
+    Principal.create!(kind: 'service', email: 'echo@echonet.org',
+                      identity_issuer: 'spec')
+  end
+  let(:task) { Rake::Task['plants:import'].tap(&:reenable) }
+  let(:uuid) { SecureRandom.uuid }
+
+  # Hold a reference: a Tempfile deletes itself when garbage collected, and the
+  # rake task then aborts on a missing file, which takes the whole suite with it.
+  def write_fixture(records)
+    @fixtures ||= []
+    file = Tempfile.new(['import', '.json'])
+    @fixtures << file
+    file.write(JSON.generate(records))
+    file.flush
+    file.path
+  end
+
+  def record(overrides = {})
+    {
+      'uuid' => uuid,
+      'scientific_name' => 'Adansonia digitata',
+      'family_names' => 'Malvaceae',
+      'life_cycle' => 'perennial',
+      'has_edible_green_leaves' => true,
+      'has_edible_immature_fruit' => false,
+      'has_edible_mature_fruit' => false,
+      'can_be_used_for_fodder' => false,
+      'optimal_temperature_range' => '20..35',
+      'ph_range' => nil,
+      'common_names' => { 'EN' => [{ 'name' => 'Baobab', 'location' => nil },
+                                   { 'name' => 'Monkey Bread Tree', 'location' => nil }] },
+      'translations' => {
+        'en' => { 'locale' => 'en', 'primary_common_name' => 'Baobab',
+                  'description' => 'Short summary.',
+                  'info_sheet_description' => 'The long narrative.',
+                  'uses' => 'Leaves and fruit.' }
+      }
+    }.merge(overrides)
+  end
+
+  def run(path, apply: true)
+    ClimateControl.modify(ECHO_ORG_ID: org.id, APPLY: apply ? 'true' : nil) do
+      task.invoke(path)
+    end
+  rescue NameError
+    # ClimateControl is not in this bundle; fall back to setting ENV directly.
+    ENV['ECHO_ORG_ID'] = org.id
+    apply ? ENV['APPLY'] = 'true' : ENV.delete('APPLY')
+    task.invoke(path)
+  ensure
+    ENV.delete('APPLY')
+    ENV.delete('ECHO_ORG_ID')
+  end
+
+  it 'creates a plant with its translations, ownership and common names' do
+    expect { run(write_fixture([record])) }.to change(Plant, :count).by(1)
+
+    plant = Plant.find(uuid)
+    aggregate_failures do
+      expect(plant.scientific_name).to eq 'Adansonia digitata'
+      expect(plant.owner_organization_id).to eq org.id
+      expect(plant.created_by_principal_id).to eq service_principal.id
+      expect(plant.access_level).to eq 'public'
+      expect(plant.optimal_temperature_range).to eq(20...36)
+      expect(plant.description).to eq 'Short summary.'
+      expect(plant.info_sheet_description).to eq 'The long narrative.'
+      expect(plant.common_names.count).to eq 2
+    end
+  end
+
+  it 'marks the common name matching the ECHOcommunity title as primary' do
+    run(write_fixture([record]))
+
+    names = Plant.find(uuid).common_names.index_by(&:name)
+    expect(names['Baobab'].primary).to be true
+    expect(names['Monkey Bread Tree'].primary).to be false
+  end
+
+  # The range columns default to values nobody measured -- ph_range to
+  # '[0.0,14.0]', optimal_temperature_range to '[0,61)'. An absent range has to
+  # be written as NULL or the record silently claims those tolerances.
+  it 'writes absent ranges as NULL rather than accepting the column defaults' do
+    run(write_fixture([record]))
+
+    plant = Plant.find(uuid)
+    aggregate_failures do
+      expect(plant.ph_range).to be_nil
+      expect(plant.n_accumulation_range).to be_nil
+      expect(plant.biomass_production_range).to be_nil
+      expect(plant.optimal_altitude_range).to be_nil
+    end
+  end
+
+  it 'is idempotent: an existing uuid is skipped, not overwritten' do
+    path = write_fixture([record])
+    run(path)
+    Plant.find(uuid).update!(scientific_name: 'Edited locally')
+
+    expect { run(path) }.not_to change(Plant, :count)
+    expect(Plant.find(uuid).scientific_name).to eq 'Edited locally'
+  end
+
+  it 'writes nothing without APPLY' do
+    expect { run(write_fixture([record]), apply: false) }.not_to change(Plant, :count)
+  end
+end


### PR DESCRIPTION
Phase 1 of the plant-data ownership migration. Imports plants exported from
ECHOcommunity so the API can become the system of record for them.

## Shape

Consumes the same JSON as `db/seeds/Plants.json`, so the export tooling targets
a format this app already understands rather than a new one. Logic lives in
`lib/ec_plant_importer.rb` with a thin rake wrapper, following
`staging_rehearsal.rake`.

```
bin/rails plants:import[tmp/import.json]              # dry run
APPLY=true bin/rails plants:import[tmp/import.json]   # write
```

`ECHO_ORG_ID` selects the owning organization — staging uses
`StagingRehearsalMapping::ECHO_ORG_ID`.

Writes go through the model layer, never SQL, so Mobility translations, the
visibility trio and PaperTrail all behave normally. Idempotent: an existing
uuid is skipped, never overwritten — bringing a record up to date is
reconciliation, which is a separate concern with conflict handling.

## Two decisions worth reviewing

**Absent ranges are written as NULL explicitly.** These columns carry defaults
that assert facts nobody measured:

| column | default |
|---|---|
| `ph_range` | `[0.0,14.0]` |
| `optimal_temperature_range` | `[0,61)` |
| `n_accumulation_range` | `[0,1)` |
| `biomass_production_range` | `[0.0,0.0]` |
| `optimal_rainfall_range`, `optimal_altitude_range` | `[0,)` |

Omitting an absent range therefore records *"tolerates pH 0–14"* rather than
*"unknown"*. That is how the 2020 seed left **174 of its 322 plants** claiming
exactly that, and it is worth knowing those rows are still in production. There
is a spec pinning this behaviour.

**`created_by_principal_id`.** It is NOT NULL, and a `real` organization such as
ECHO has no principal of its own — only `personal` orgs do. Production
attributes its 322 seeded plants to the **service** principal for
`echo@echonet.org`, so that is the default here, overridable with
`ECHO_PRINCIPAL_ID`.

## Verification

Run against a copy of the 70 published ECHOcommunity plants currently absent
from the API: 70 created, all public and not deleted, 177 common names, and
every range NULL where the source had no value. Field mapping spot-checked
against source — the baobab's `resource.description` (1,376 chars),
`plant.description` (2,219) and `plant.uses` (2,167) land in `description`,
`info_sheet_description` and `uses` respectively.

- 5 new specs covering creation, the primary-common-name rule, NULL ranges,
  idempotency and the dry-run default
- **Full suite: 2,312 examples, 0 failures**
- Rubocop clean (`plant_import.rake` added to the `Metrics/BlockLength` exclude
  list alongside `ownership.rake`)

Depends on nothing else; #116 is independent.