### PR TITLE
Add plants:align_visibility for the ECHOcommunity plant migration

### DIFF
--- a/lib/ec_visibility_aligner.rb
+++ b/lib/ec_visibility_aligner.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Aligns Plant API visibility with ECHOcommunity's editorial state.
+#
+# ECHOcommunity decides whether a plant is published (migration decision D-007),
+# and its deletions made after the 2020 export are authoritative too (D-014).
+# Both are carried in as a status file rather than a live database connection,
+# so this application never holds a handle on ECHOcommunity's database (D-029).
+#
+# Only plants owned by the given organization are touched, and only when their
+# visibility actually differs. A plant with no entry in the status file is left
+# alone: it exists only in the API, which is legitimate (the 2026-08-07 Acacia
+# split, and 107 contributed plants), and silence is not evidence of deletion.
+class EcVisibilityAligner
+  Result = Struct.new(:changed, :unchanged, :absent, :failed, :changes, :errors,
+                      keyword_init: true)
+
+  # ECHOcommunity status -> Plant API visibility.
+  TARGET = { 'published' => :public, 'draft' => :draft, 'deleted' => :deleted }.freeze
+
+  def initialize(organization:, statuses:, apply: false)
+    @organization = organization
+    @statuses = statuses
+    @apply = apply
+  end
+
+  def align
+    result = Result.new(changed: 0, unchanged: 0, absent: 0, failed: 0,
+                        changes: [], errors: [])
+    scope.find_each { |plant| align_plant(plant, result) }
+    result
+  end
+
+  private
+
+  def scope
+    Plant.unscoped.where(owner_organization_id: @organization.id)
+  end
+
+  def align_plant(plant, result)
+    status = @statuses[plant.id]
+    return result.absent += 1 if status.nil?
+
+    target = TARGET[status]
+    return result.unchanged += 1 if unchanged?(plant, target)
+
+    record_change(plant, target, status, result)
+    plant.update!(visibility: target) if @apply
+  rescue StandardError => e
+    record_failure(plant, e, result)
+  end
+
+  def record_failure(plant, error, result)
+    result.failed += 1
+    result.changed -= 1
+    result.errors << "#{plant.id}: #{error.class}: #{error.message}"
+  end
+
+  def unchanged?(plant, target)
+    target.nil? || plant.visibility.to_s == target.to_s
+  end
+
+  def record_change(plant, target, status, result)
+    result.changes << "#{plant.id} #{plant.scientific_name}: " \
+                      "#{plant.visibility} -> #{target} (EC: #{status})"
+    result.changed += 1
+  end
+end

--- a/lib/tasks/plant_visibility.rake
+++ b/lib/tasks/plant_visibility.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_visibility_aligner')
+
+# Thin wrapper; the reasoning lives in lib/ec_visibility_aligner.rb.
+#
+#   bin/rails plants:align_visibility[tmp/status.json]              # dry run
+#   APPLY=true bin/rails plants:align_visibility[tmp/status.json]   # write
+#
+# The status file comes from tools/export_ec_status.py in the migration
+# workspace. ECHO_ORG_ID selects the organization whose plants are aligned.
+namespace :plants do
+  desc 'Align plant visibility with ECHOcommunity status (dry run unless APPLY=true)'
+  task :align_visibility, [:path] => :environment do |_t, args|
+    path = args[:path] or abort 'usage: bin/rails plants:align_visibility[path/to/status.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    org_id = ENV['ECHO_ORG_ID'].presence or abort 'ECHO_ORG_ID is required'
+    org = Organization.find_by(id: org_id) or abort "no organization with id #{org_id}"
+
+    payload = JSON.parse(File.read(path))
+    statuses = payload['statuses'] or abort "no 'statuses' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'ALIGNING' : 'DRY RUN'} against #{statuses.size} " \
+         "ECHOcommunity statuses from #{path}"
+    puts "  source environment: #{payload['source'] || 'unknown'}"
+    puts "  organization:       #{org.name} (#{org.id})"
+    puts
+
+    result = EcVisibilityAligner.new(organization: org, statuses: statuses,
+                                     apply: apply).align
+
+    result.changes.first(40).each { |c| puts "    #{c}" }
+    puts if result.changes.any?
+    puts "  #{apply ? 'changed' : 'would change'}: #{result.changed}"
+    puts "  already correct: #{result.unchanged}"
+    puts "  not in ECHOcommunity (left alone): #{result.absent}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'alignment finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/plant_visibility_spec.rb
+++ b/spec/tasks/plant_visibility_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EcVisibilityAligner do
+  let(:org)   { create(:organization, :real) }
+  let(:other) { create(:organization, :real) }
+
+  def plant(visibility:, organization: org)
+    create(:plant, owner_organization_id: organization.id,
+                   source_organization_id: organization.id,
+                   visibility: visibility)
+  end
+
+  def align(statuses, apply: true)
+    described_class.new(organization: org, statuses: statuses, apply: apply).align
+  end
+
+  it 'hides a plant ECHOcommunity has as draft' do
+    p = plant(visibility: :public)
+    result = align({ p.id => 'draft' })
+
+    expect(result.changed).to eq 1
+    expect(p.reload.visibility).to eq 'draft'
+  end
+
+  it 'hides a plant ECHOcommunity has deleted' do
+    p = plant(visibility: :public)
+    align({ p.id => 'deleted' })
+
+    expect(p.reload.visibility).to eq 'deleted'
+  end
+
+  it 'publishes a plant ECHOcommunity has published' do
+    p = plant(visibility: :draft)
+    align({ p.id => 'published' })
+
+    expect(p.reload.visibility).to eq 'public'
+  end
+
+  it 'counts an already-correct plant as unchanged and writes nothing' do
+    p = plant(visibility: :public)
+    result = align({ p.id => 'published' })
+
+    expect(result.changed).to eq 0
+    expect(result.unchanged).to eq 1
+  end
+
+  # Absence from the status file means "ECHOcommunity has never heard of this",
+  # which is true of the 107 contributed plants and the 2026-08-07 Acacia split.
+  # Silence must not be read as a deletion.
+  it 'leaves a plant absent from the status file untouched' do
+    p = plant(visibility: :public)
+    result = align({})
+
+    expect(result.absent).to eq 1
+    expect(p.reload.visibility).to eq 'public'
+  end
+
+  it 'ignores plants owned by another organization' do
+    p = plant(visibility: :public, organization: other)
+    align({ p.id => 'draft' })
+
+    expect(p.reload.visibility).to eq 'public'
+  end
+
+  it 'writes nothing when not applying' do
+    p = plant(visibility: :public)
+    result = align({ p.id => 'draft' }, apply: false)
+
+    expect(result.changed).to eq 1
+    expect(p.reload.visibility).to eq 'public'
+  end
+end


### PR DESCRIPTION
Phase 1 of the plant-data ownership migration, and the companion to #117.

Aligns Plant API visibility with ECHOcommunity's editorial state. ECHOcommunity
decides whether a plant is published, and its deletions made after the 2020
export are authoritative — several plants it removed years ago are still public
in the API today.

```
bin/rails plants:align_visibility[tmp/status.json]              # dry run
APPLY=true bin/rails plants:align_visibility[tmp/status.json]   # write
```

The status file is produced by the migration workspace, so this application
never holds a connection to ECHOcommunity's database.

## Behaviour worth reviewing

- Only plants owned by `ECHO_ORG_ID` are considered, and only those whose
  visibility actually differs are written.
- **A plant absent from the status file is left alone.** That covers the 107
  contributed plants and the three species created by the 2026-08-07 Acacia
  split — records that legitimately exist only in the API. Silence in the file
  is not evidence of deletion, and there is a spec pinning that.
- Mapping is `published → public`, `draft → draft`, `deleted → deleted`, applied
  through `update!` so the visibility trio and PaperTrail behave normally.

## Rehearsed against staging

After #117's import ran, this task changed **73** records — 67 ECHOcommunity
drafts to `draft` and 6 deletions to `deleted` — with 319 already correct and no
failures. The migration's cutover guard then reported:

```
  ECHOcommunity published          319
  Plant API ECHO-public            319
  in both                          319
  would VANISH from the site         0
  would APPEAR from the site         0
  PASS
```

That is the Phase 1 exit criterion met in the rehearsal environment: a cutover
would change nothing publicly.

- 7 new specs
- **Full suite: 2,319 examples, 0 failures**
- Rubocop clean

Independent of #116 and #117; can merge in any order.