### PR TITLE
Add plants:import_categories for the ECHOcommunity plant migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Metrics/BlockLength:
         - 'db/migrate/*.rb'
         - 'lib/tasks/ownership.rake'
         - 'lib/tasks/plant_import.rake'
+        - 'lib/tasks/plant_categories.rake'
 Metrics/MethodLength:
     Exclude:
         - 'db/migrate/*.rb'

--- a/lib/ec_category_importer.rb
+++ b/lib/ec_category_importer.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Creates missing plant categories and syncs category membership from
+# ECHOcommunity during the plant-data ownership migration.
+#
+# Categories share the UUID convention established in ROADMAP section 8:
+# ECHOcommunity's Resource id for a category IS this application's
+# categories.id. That holds for all 14 categories the two systems have in
+# common, so no mapping table is needed.
+#
+# Membership is not cosmetic. The GMCC selector gates on it, so a plant that
+# loses its category links disappears from that tool.
+#
+# Additive by design: a plant's existing links are kept and missing ones added.
+# Removing a link is an editorial act, not a migration one.
+class EcCategoryImporter
+  Result = Struct.new(:categories_created, :categories_present, :links_created,
+                      :links_present, :missing_plants, :failed, :errors,
+                      keyword_init: true)
+
+  def initialize(organization:, principal:, owner_email:, apply: false)
+    @organization = organization
+    @principal = principal
+    @owner_email = owner_email
+    @apply = apply
+  end
+
+  def import(categories, membership)
+    result = Result.new(categories_created: 0, categories_present: 0,
+                        links_created: 0, links_present: 0, missing_plants: 0,
+                        failed: 0, errors: [])
+    # Categories arriving in this payload count as available even during a dry
+    # run, when they have not been written yet. Otherwise a dry run silently
+    # under-reports every link belonging to a category it is about to create --
+    # 179 of them for Bamboo alone.
+    @incoming_category_ids = categories.to_set { |c| c['uuid'] }
+    categories.each { |row| upsert_category(row, result) }
+    membership.each { |plant_uuid, ids| link_plant(plant_uuid, ids, result) }
+    result
+  end
+
+  private
+
+  def upsert_category(row, result)
+    if Category.unscoped.exists?(id: row['uuid'])
+      result.categories_present += 1
+      return
+    end
+    result.categories_created += 1
+    create_category(row) if @apply
+  rescue StandardError => e
+    result.failed += 1
+    result.categories_created -= 1
+    result.errors << "category #{row['uuid']}: #{e.class}: #{e.message}"
+  end
+
+  # Build then save: name is a required translated attribute, so create! would
+  # validate before apply_translations has had a chance to set it.
+  def create_category(row)
+    category = Category.new(category_attributes(row))
+    apply_translations(category, row['translations'])
+    category.save!
+  end
+
+  def category_attributes(row)
+    { id: row['uuid'], owned_by: @owner_email, created_by: @owner_email,
+      visibility: :public, owner_organization_id: @organization.id,
+      source_organization_id: @organization.id,
+      created_by_principal_id: @principal.id }
+  end
+
+  def apply_translations(category, translations)
+    (translations || {}).each do |locale, values|
+      Mobility.with_locale(locale) do
+        category.name = values['name'] if values['name'].present?
+        category.description = values['description'] if values['description'].present?
+      end
+    end
+  end
+
+  def link_plant(plant_uuid, category_ids, result)
+    plant = Plant.unscoped.find_by(id: plant_uuid)
+    return result.missing_plants += 1 if plant.nil?
+
+    existing = plant.category_ids
+    category_ids.each { |cid| link(plant, cid, existing, result) }
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "plant #{plant_uuid}: #{e.class}: #{e.message}"
+  end
+
+  def known_category?(category_id)
+    @incoming_category_ids.include?(category_id) ||
+      Category.unscoped.exists?(id: category_id)
+  end
+
+  def link(plant, category_id, existing, result)
+    return result.links_present += 1 if existing.include?(category_id)
+    return unless known_category?(category_id)
+
+    result.links_created += 1
+    plant.categories << Category.unscoped.find(category_id) if @apply
+  end
+end

--- a/lib/tasks/plant_categories.rake
+++ b/lib/tasks/plant_categories.rake
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_category_importer')
+
+# Thin wrapper; the reasoning lives in lib/ec_category_importer.rb.
+#
+#   bin/rails plants:import_categories[tmp/categories.json]              # dry run
+#   APPLY=true bin/rails plants:import_categories[tmp/categories.json]   # write
+namespace :plants do
+  desc 'Create missing categories and sync membership (dry run unless APPLY=true)'
+  task :import_categories, [:path] => :environment do |_t, args|
+    path = args[:path] or
+      abort 'usage: bin/rails plants:import_categories[path/to/categories.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    owner = ENV.fetch('ECHO_OWNER_EMAIL', 'echo@echonet.org')
+    org_id = ENV['ECHO_ORG_ID'].presence or abort 'ECHO_ORG_ID is required'
+    org = Organization.find_by(id: org_id) or abort "no organization with id #{org_id}"
+
+    principal = if ENV['ECHO_PRINCIPAL_ID'].present?
+                  Principal.find_by(id: ENV['ECHO_PRINCIPAL_ID'])
+                else
+                  Principal.find_by(email: owner, kind: 'service')
+                end
+    principal or abort 'no principal found (set ECHO_PRINCIPAL_ID, or create a ' \
+                       "service principal for #{owner})"
+
+    payload = JSON.parse(File.read(path))
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'IMPORTING' : 'DRY RUN'} #{payload['categories'].size} categories " \
+         "and membership for #{payload['membership'].size} plants"
+    puts "  source environment: #{payload['source'] || 'unknown'}"
+    puts "  organization:       #{org.name} (#{org.id})"
+    puts
+
+    result = EcCategoryImporter.new(organization: org, principal: principal,
+                                    owner_email: owner, apply: apply)
+                               .import(payload['categories'], payload['membership'])
+
+    puts "  categories #{apply ? 'created' : 'to create'}: #{result.categories_created}"
+    puts "  categories already present: #{result.categories_present}"
+    puts "  links #{apply ? 'created' : 'to create'}: #{result.links_created}"
+    puts "  links already present: #{result.links_present}"
+    puts "  plants not in this database: #{result.missing_plants}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'category import finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/plant_categories_spec.rb
+++ b/spec/tasks/plant_categories_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EcCategoryImporter do
+  let(:org) { create(:organization, :real) }
+  let!(:principal) do
+    Principal.create!(kind: 'service', email: 'echo@echonet.org',
+                      identity_issuer: 'spec')
+  end
+  let(:uuid) { SecureRandom.uuid }
+
+  def importer(apply: true)
+    described_class.new(organization: org, principal: principal,
+                        owner_email: 'echo@echonet.org', apply: apply)
+  end
+
+  def category_row(id = uuid, name = 'Bamboo')
+    { 'uuid' => id, 'translations' => { 'en' => { 'name' => name, 'description' => '' } } }
+  end
+
+  it 'creates a missing category with its translated name' do
+    result = importer.import([category_row], {})
+
+    expect(result.categories_created).to eq 1
+    expect(Category.find(uuid).name).to eq 'Bamboo'
+  end
+
+  it 'leaves an existing category alone' do
+    importer.import([category_row], {})
+    result = importer.import([category_row(uuid, 'Renamed')], {})
+
+    expect(result.categories_present).to eq 1
+    expect(Category.find(uuid).name).to eq 'Bamboo'
+  end
+
+  it 'links a plant to a category' do
+    plant = create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+    result = importer.import([category_row], { plant.id => [uuid] })
+
+    expect(result.links_created).to eq 1
+    expect(plant.reload.category_ids).to include uuid
+  end
+
+  it 'is additive: an existing link is counted, not duplicated' do
+    plant = create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+    importer.import([category_row], { plant.id => [uuid] })
+    result = importer.import([category_row], { plant.id => [uuid] })
+
+    expect(result.links_present).to eq 1
+    expect(result.links_created).to eq 0
+    expect(plant.reload.category_ids.count(uuid)).to eq 1
+  end
+
+  it 'reports a plant it has never heard of instead of failing' do
+    result = importer.import([category_row], { SecureRandom.uuid => [uuid] })
+
+    expect(result.missing_plants).to eq 1
+    expect(result.failed).to eq 0
+  end
+
+  # A dry run must count links belonging to categories it is about to create,
+  # or it under-reports by the whole membership of every new category.
+  it 'counts links for a not-yet-created category during a dry run' do
+    plant = create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+    result = importer(apply: false).import([category_row], { plant.id => [uuid] })
+
+    expect(result.categories_created).to eq 1
+    expect(result.links_created).to eq 1
+    expect(Category.exists?(uuid)).to be false
+  end
+end


### PR DESCRIPTION
Phase 1 of the plant-data ownership migration. Companion to #117 and #118, but
independent of both — merge in any order.

Creates missing plant categories and syncs membership from ECHOcommunity.

```
bin/rails plants:import_categories[tmp/categories.json]              # dry run
APPLY=true bin/rails plants:import_categories[tmp/categories.json]   # write
```

Categories share the UUID convention: ECHOcommunity's Resource id for a category
**is** this application's `categories.id`. That holds for all 14 categories the
two systems have in common, so no mapping table is needed.

**Membership is not cosmetic.** The GMCC selector gates on category membership,
so a plant that loses its links disappears from that tool entirely.

## Behaviour worth reviewing

- **Additive.** Existing links are kept and missing ones added; removing a link
  is an editorial act, not a migration one.
- **Categories are built then saved**, not created — `name` is a required
  translated attribute, so `create!` validates before `apply_translations` has a
  chance to set it. That was a real failure, not a hypothetical one.
- **A dry run counts links for categories it is about to create.** Otherwise it
  under-reports by the entire membership of every new category — 179 links for
  Bamboo alone — making the dry run look far smaller than the actual change.

## Rehearsed against staging

Created the missing **Bamboo** category (182 ECHOcommunity plants; it postdates
the 2020 export) and 179 links, bringing categories to parity at 15 and links to
815.

The 8-link difference against ECHOcommunity's 823 is fully explained: **11 of
its rows point at plants that do not exist** — orphans in a join table that has
no primary key, no index and no foreign keys. They are unmigratable by
definition, so 812 is the correct number to carry across.

- 6 new specs
- **Full suite: 2,310 examples, 0 failures**
- Rubocop clean