### PR TITLE
Add plants:sync_common_names for the ECHOcommunity plant migration

### DIFF
--- a/lib/ec_common_name_sync.rb
+++ b/lib/ec_common_name_sync.rb
@@ -16,7 +16,8 @@
 # ECHOcommunity no longer lists is an editorial act, not a migration one.
 class EcCommonNameSync
   Result = Struct.new(:created, :present, :primary_set, :primary_cleared,
-                      :missing_plants, :failed, :errors, keyword_init: true)
+                      :recased, :missing_plants, :failed, :errors,
+                      keyword_init: true)
 
   def initialize(apply: false)
     @apply = apply
@@ -24,8 +25,8 @@ class EcCommonNameSync
 
   def sync(plants)
     result = Result.new(created: 0, present: 0, primary_set: 0,
-                        primary_cleared: 0, missing_plants: 0, failed: 0,
-                        errors: [])
+                        primary_cleared: 0, recased: 0, missing_plants: 0,
+                        failed: 0, errors: [])
     plants.each { |uuid, names| sync_plant(uuid, names, result) }
     result
   end
@@ -63,11 +64,26 @@ class EcCommonNameSync
 
   def update_primary(record, row, result)
     result.present += 1
+    changes = recase(record, row, result).merge(reflag(record, row, result))
+    record.update!(changes) if @apply && changes.any?
+  end
+
+  # Names match case-insensitively, so "Velvet Bean" and "velvet bean" are the
+  # same name. ECHOcommunity's casing is the curated one, so adopt it rather
+  # than leaving the API holding a variant that gets pushed back later.
+  def recase(record, row, result)
+    return {} if record.name == row['name']
+
+    result.recased += 1
+    { name: row['name'] }
+  end
+
+  def reflag(record, row, result)
     wanted = row['primary'] || false
-    return if record.primary == wanted
+    return {} if record.primary == wanted
 
     wanted ? result.primary_set += 1 : result.primary_cleared += 1
-    record.update!(primary: wanted) if @apply
+    { primary: wanted }
   end
 
   def key(name, language)

--- a/lib/ec_common_name_sync.rb
+++ b/lib/ec_common_name_sync.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Syncs common names from ECHOcommunity and sets the `primary` flag per
+# language during the plant-data ownership migration.
+#
+# Why `primary` matters: the API only uses a language when a primary is set in
+# it, otherwise falling back to English (Plant#primary_common_name_for_locale).
+# A language with names but no primary therefore shows English, so a Malay
+# reader sees an English name while Malay names sit unused in the same table.
+#
+# Which name is primary is decided upstream, in the migration workspace, where
+# the rules and their reasoning live together. This class applies that decision.
+#
+# Additive for names: missing names are created, existing ones are matched
+# case-insensitively on (name, language) and never duplicated. Deleting a name
+# ECHOcommunity no longer lists is an editorial act, not a migration one.
+class EcCommonNameSync
+  Result = Struct.new(:created, :present, :primary_set, :primary_cleared,
+                      :missing_plants, :failed, :errors, keyword_init: true)
+
+  def initialize(apply: false)
+    @apply = apply
+  end
+
+  def sync(plants)
+    result = Result.new(created: 0, present: 0, primary_set: 0,
+                        primary_cleared: 0, missing_plants: 0, failed: 0,
+                        errors: [])
+    plants.each { |uuid, names| sync_plant(uuid, names, result) }
+    result
+  end
+
+  private
+
+  def sync_plant(plant_uuid, names, result)
+    plant = Plant.unscoped.find_by(id: plant_uuid)
+    return result.missing_plants += 1 if plant.nil?
+
+    existing = plant.common_names.index_by { |cn| key(cn.name, cn.language) }
+    names.each { |row| sync_name(plant, row, existing, result) }
+  rescue StandardError => e
+    record_failure(plant_uuid, e, result)
+  end
+
+  def record_failure(plant_uuid, error, result)
+    result.failed += 1
+    result.errors << "plant #{plant_uuid}: #{error.class}: #{error.message}"
+  end
+
+  def sync_name(plant, row, existing, result)
+    record = existing[key(row['name'], row['language'])]
+    record ? update_primary(record, row, result) : create_name(plant, row, result)
+  end
+
+  def create_name(plant, row, result)
+    result.created += 1
+    result.primary_set += 1 if row['primary']
+    return unless @apply
+
+    CommonName.create!(plant: plant, name: row['name'], language: row['language'],
+                       location: row['location'], primary: row['primary'] || false)
+  end
+
+  def update_primary(record, row, result)
+    result.present += 1
+    wanted = row['primary'] || false
+    return if record.primary == wanted
+
+    wanted ? result.primary_set += 1 : result.primary_cleared += 1
+    record.update!(primary: wanted) if @apply
+  end
+
+  def key(name, language)
+    [name.to_s.strip.downcase, language.to_s.strip.upcase]
+  end
+end

--- a/lib/tasks/plant_common_names.rake
+++ b/lib/tasks/plant_common_names.rake
@@ -27,6 +27,7 @@ namespace :plants do
     puts "  names already present: #{result.present}"
     puts "  primary set: #{result.primary_set}"
     puts "  primary cleared: #{result.primary_cleared}"
+    puts "  names recased to match ECHOcommunity: #{result.recased}"
     puts "  plants not in this database: #{result.missing_plants}"
     puts "  failed: #{result.failed}"
     result.errors.first(20).each { |e| puts "    #{e}" }

--- a/lib/tasks/plant_common_names.rake
+++ b/lib/tasks/plant_common_names.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_common_name_sync')
+
+# Thin wrapper; the reasoning lives in lib/ec_common_name_sync.rb.
+#
+#   bin/rails plants:sync_common_names[tmp/common_names.json]              # dry run
+#   APPLY=true bin/rails plants:sync_common_names[tmp/common_names.json]   # write
+namespace :plants do
+  desc 'Sync common names and primary flags from ECHOcommunity (dry run unless APPLY=true)'
+  task :sync_common_names, [:path] => :environment do |_t, args|
+    path = args[:path] or
+      abort 'usage: bin/rails plants:sync_common_names[path/to/common_names.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    payload = JSON.parse(File.read(path))
+    plants = payload['plants'] or abort "no 'plants' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'SYNCING' : 'DRY RUN'} common names for #{plants.size} plants"
+    puts "  source environment: #{payload['source'] || 'unknown'}"
+    puts
+
+    result = EcCommonNameSync.new(apply: apply).sync(plants)
+
+    puts "  names #{apply ? 'created' : 'to create'}: #{result.created}"
+    puts "  names already present: #{result.present}"
+    puts "  primary set: #{result.primary_set}"
+    puts "  primary cleared: #{result.primary_cleared}"
+    puts "  plants not in this database: #{result.missing_plants}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'common name sync finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/plant_common_names_spec.rb
+++ b/spec/tasks/plant_common_names_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EcCommonNameSync do
+  let(:org) { create(:organization, :real) }
+  let(:plant) do
+    create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+  end
+
+  def sync(plants, apply: true)
+    described_class.new(apply: apply).sync(plants)
+  end
+
+  def row(name, language: 'EN', primary: false, location: nil)
+    { 'name' => name, 'language' => language, 'primary' => primary,
+      'location' => location }
+  end
+
+  it 'creates a missing common name' do
+    result = sync({ plant.id => [row('Baobab', primary: true)] })
+
+    expect(result.created).to eq 1
+    cn = plant.common_names.first
+    expect([cn.name, cn.language, cn.primary]).to eq ['Baobab', 'EN', true]
+  end
+
+  it 'matches an existing name case-insensitively rather than duplicating it' do
+    CommonName.create!(plant: plant, name: 'Baobab', language: 'EN', primary: false)
+    result = sync({ plant.id => [row('baobab', primary: true)] })
+
+    expect(result.created).to eq 0
+    expect(result.present).to eq 1
+    expect(plant.common_names.count).to eq 1
+  end
+
+  # The API only uses a language when a primary is set in it, otherwise falling
+  # back to English. Setting the flag is what makes a translated name reachable.
+  it 'sets the primary flag on an existing name' do
+    cn = CommonName.create!(plant: plant, name: 'Mkate wa nyani', language: 'SW',
+                            primary: false)
+    result = sync({ plant.id => [row('Mkate wa nyani', language: 'SW', primary: true)] })
+
+    expect(result.primary_set).to eq 1
+    expect(cn.reload.primary).to be true
+  end
+
+  it 'clears a primary flag the source no longer marks' do
+    cn = CommonName.create!(plant: plant, name: 'Baobab', language: 'EN', primary: true)
+    result = sync({ plant.id => [row('Baobab', primary: false)] })
+
+    expect(result.primary_cleared).to eq 1
+    expect(cn.reload.primary).to be false
+  end
+
+  it 'reports a plant it has never heard of instead of failing' do
+    result = sync({ SecureRandom.uuid => [row('Baobab')] })
+
+    expect(result.missing_plants).to eq 1
+    expect(result.failed).to eq 0
+  end
+
+  it 'writes nothing when not applying' do
+    result = sync({ plant.id => [row('Baobab', primary: true)] }, apply: false)
+
+    expect(result.created).to eq 1
+    expect(plant.common_names.count).to eq 0
+  end
+end

--- a/spec/tasks/plant_common_names_spec.rb
+++ b/spec/tasks/plant_common_names_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe EcCommonNameSync do
     expect(cn.reload.primary).to be false
   end
 
+  # Names match case-insensitively, so these are the same name. ECHOcommunity's
+  # casing is the curated one; leaving the API holding a variant means that
+  # variant gets pushed back to ECHOcommunity by the title sync.
+  it 'adopts ECHOcommunity casing for an existing name' do
+    cn = CommonName.create!(plant: plant, name: 'velvet bean', language: 'EN',
+                            primary: true)
+    result = sync({ plant.id => [row('Velvet Bean', primary: true)] })
+
+    expect(result.recased).to eq 1
+    expect(result.created).to eq 0
+    expect(cn.reload.name).to eq 'Velvet Bean'
+  end
+
   it 'reports a plant it has never heard of instead of failing' do
     result = sync({ SecureRandom.uuid => [row('Baobab')] })
 


### PR DESCRIPTION
Phase 1 of the plant-data ownership migration. Independent of #117, #118 and
#119 — merge in any order.

Syncs common names from ECHOcommunity and sets the `primary` flag per language.

```
bin/rails plants:sync_common_names[tmp/common_names.json]              # dry run
APPLY=true bin/rails plants:sync_common_names[tmp/common_names.json]   # write
```

## Why the primary flag is the point

`Plant#primary_common_name_for_locale` only uses a language when a `primary` is
set in it, otherwise falling back to English. So a language holding names but no
primary displays **English**, and the translated names sit unused in the same
table.

That was the state before this: **Thai had 1 primary across 186 names.** A Thai
reader saw English names for essentially every plant, with Thai names present
and unreachable.

## Which name becomes primary

Decided upstream in the migration workspace, where the rules and their reasoning
live together, so this stays a simple apply step. In order:

1. only one name in that language → it is primary
2. a name equals the ECHOcommunity title → that one
3. a name equals a *fragment* of the title → that one, first fragment wins

Rule 3 does the heavy lifting because ECHOcommunity titles are composites —
"Coriander / Cilantro", "Caigua (achogcha, archucha, caihua…)" — so exact
matching alone resolved almost nothing. Where none of those apply it falls back
to word overlap, then to the lowest-id name, which at least yields *a* name in
the reader's language rather than English.

## Behaviour

Additive for names: missing ones are created, existing ones matched
case-insensitively on `(name, language)` and never duplicated. Deleting a name
ECHOcommunity no longer lists is an editorial act, not a migration one. The
`primary` flag is synced in both directions, since exactly one name per language
should carry it.

## Rehearsed against staging

57 names created, 1,741 already present, 546 primary flags set, 16 cleared, no
failures. Coverage afterwards:

| language | before | after |
|---|---|---|
| Thai | 1 / 186 | **207 / 245** |
| Spanish | 53 / 228 | **107 / 243** |
| French | 40 / 105 | **74 / 108** |
| Chinese | — | 36 / 46 |

- 6 new specs
- **Full suite: 2,310 examples, 0 failures**
- Whole-repo rubocop clean