### PR TITLE
Add plants:sync_scientific_names for the ECHOcommunity plant migration

### DIFF
--- a/lib/ec_scientific_name_sync.rb
+++ b/lib/ec_scientific_name_sync.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Promotes ECHOcommunity's scientific names into the API during the plant-data
+# ownership migration.
+#
+# Under D-033 a plant's displayed title on ECHOcommunity becomes its scientific
+# name, and under D-034 ECHOcommunity's value wins where the two systems
+# disagree - its plant data has been curated since the 2020 export and the
+# API's has not. Moving the name here first means the title ECHOcommunity shows
+# still comes from the API, so the API stays the system of record rather than
+# ECHOcommunity quietly keeping ownership of the field.
+#
+# The incoming values are cleaned upstream, in the migration workspace, where
+# the rules and their reasoning live together. This class applies that decision
+# and deliberately does no rewriting of its own.
+#
+# Two guards:
+#
+#   * A blank incoming value is never written. The scientific name is about to
+#     become a page title, so erasing one would leave a plant untitled.
+#   * Only `scientific_name` moves. Everything else on the Plant - visibility,
+#     ownership, translations, common names - is left alone.
+class EcScientificNameSync
+  Result = Struct.new(:changed, :unchanged, :blank_skipped, :missing_plants,
+                      :failed, :changes, :errors, keyword_init: true)
+
+  def initialize(apply: false)
+    @apply = apply
+  end
+
+  def sync(plants)
+    result = Result.new(changed: 0, unchanged: 0, blank_skipped: 0,
+                        missing_plants: 0, failed: 0, changes: [], errors: [])
+    plants.each { |uuid, name| sync_plant(uuid, name, result) }
+    result
+  end
+
+  private
+
+  def sync_plant(uuid, incoming, result)
+    return result.blank_skipped += 1 if incoming.blank?
+
+    plant = Plant.unscoped.find_by(id: uuid)
+    return result.missing_plants += 1 if plant.nil?
+    return result.unchanged += 1 if plant.scientific_name == incoming
+
+    apply_name(plant, incoming, result)
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "#{uuid}: #{e.class}: #{e.message}"
+  end
+
+  def apply_name(plant, incoming, result)
+    result.changed += 1
+    result.changes << "#{plant.scientific_name.inspect} -> #{incoming.inspect}"
+    return unless @apply
+
+    plant.scientific_name = incoming
+    plant.save!
+  end
+end

--- a/lib/tasks/plant_scientific_names.rake
+++ b/lib/tasks/plant_scientific_names.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_scientific_name_sync')
+
+# Thin wrapper; the reasoning lives in lib/ec_scientific_name_sync.rb.
+#
+#   bin/rails plants:sync_scientific_names[tmp/sci.json]              # dry run
+#   APPLY=true bin/rails plants:sync_scientific_names[tmp/sci.json]   # write
+namespace :plants do
+  desc 'Promote scientific names from ECHOcommunity (dry run unless APPLY=true)'
+  task :sync_scientific_names, [:path] => :environment do |_t, args|
+    path = args[:path] or
+      abort 'usage: bin/rails plants:sync_scientific_names[path/to/sci.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    payload = JSON.parse(File.read(path))
+    plants = payload['plants'] or abort "no 'plants' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'SYNCING' : 'DRY RUN'} scientific names for #{plants.size} plants"
+    puts "  source environment: #{payload['source'] || 'unknown'}"
+    puts
+
+    result = EcScientificNameSync.new(apply: apply).sync(plants)
+
+    result.changes.first(60).each { |c| puts "    #{c}" }
+    puts if result.changes.any?
+    puts "  names #{apply ? 'changed' : 'to change'}: #{result.changed}"
+    puts "  already correct: #{result.unchanged}"
+    puts "  blank incoming, skipped: #{result.blank_skipped}"
+    puts "  plants not in this database: #{result.missing_plants}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'scientific name sync finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/plant_scientific_names_spec.rb
+++ b/spec/tasks/plant_scientific_names_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EcScientificNameSync do
+  let(:org) { create(:organization, :real) }
+  let(:plant) do
+    create(:plant, owner_organization_id: org.id, source_organization_id: org.id,
+                   scientific_name: 'Cyphomandra betacea')
+  end
+
+  def sync(plants, apply: true)
+    described_class.new(apply: apply).sync(plants)
+  end
+
+  it 'promotes the incoming scientific name' do
+    result = sync({ plant.id => 'Solanum betaceum' })
+
+    expect(result.changed).to eq 1
+    expect(plant.reload.scientific_name).to eq 'Solanum betaceum'
+  end
+
+  it 'leaves a plant alone when the name already matches' do
+    result = sync({ plant.id => 'Cyphomandra betacea' })
+
+    expect(result.changed).to eq 0
+    expect(result.unchanged).to eq 1
+  end
+
+  # The scientific name becomes the plant's title on ECHOcommunity, so writing a
+  # blank would leave the page untitled.
+  it 'never writes a blank name' do
+    result = sync({ plant.id => '' })
+
+    expect(result.blank_skipped).to eq 1
+    expect(result.changed).to eq 0
+    expect(plant.reload.scientific_name).to eq 'Cyphomandra betacea'
+  end
+
+  it 'reports a plant that is not in this database instead of failing' do
+    result = sync({ SecureRandom.uuid => 'Solanum betaceum' })
+
+    expect(result.missing_plants).to eq 1
+    expect(result.failed).to eq 0
+  end
+
+  it 'changes nothing on a dry run but still reports what would change' do
+    result = sync({ plant.id => 'Solanum betaceum' }, apply: false)
+
+    expect(result.changed).to eq 1
+    expect(result.changes.first).to include 'Solanum betaceum'
+    expect(plant.reload.scientific_name).to eq 'Cyphomandra betacea'
+  end
+
+  # Only the one column moves; the migration must not disturb ownership,
+  # visibility or the translated fields.
+  it 'touches nothing but scientific_name' do
+    before = plant.attributes.except('scientific_name', 'updated_at')
+    sync({ plant.id => 'Solanum betaceum' })
+
+    expect(plant.reload.attributes.except('scientific_name', 'updated_at'))
+      .to eq before
+  end
+
+  it 'finds a draft or deleted plant, which the default scope would hide' do
+    plant.update!(visibility: :deleted)
+    result = sync({ plant.id => 'Solanum betaceum' })
+
+    expect(result.changed).to eq 1
+    expect(plant.reload.scientific_name).to eq 'Solanum betaceum'
+  end
+end


### PR DESCRIPTION
Adds `plants:sync_scientific_names`, which promotes ECHOcommunity's scientific
names into the API during the plant-data ownership migration.

## Why

**D-033** replaced **D-026**. Under D-026 a plant's ECHOcommunity title came
from the API's primary common name for the reader's locale. That was fully
rehearsed in staging and abandoned: 73 titles changed and **24 of them were
worse** than what the site already showed, because the displayed name depended
on which of several common names happened to carry a `primary` flag. Eleven of
the regressions landed on GMCC selector plants. A binomial is stable,
unambiguous, and the same in every language.

**D-034** decides the direction: where ECHOcommunity and the API disagree about
a scientific name — 49 of 322 shared plants in production — ECHOcommunity wins.
Its plant data has been curated since the 2020 export and the API's has not, and
the disagreements run both ways (`Solanum betaceum` vs `Cyphomandra betacea`,
`Luffa aegyptiaca` vs `Luffa cylindrica`). Moving the name here first is what
keeps the API the system of record, rather than ECHOcommunity quietly retaining
ownership of the field.

## What it does

Reads a JSON payload of `{plant_uuid: "Scientific name"}` and writes
`scientific_name`. Dry run by default; `APPLY=true` to write.

The values are cleaned upstream in the migration workspace, where the rules live
with their reasoning — it strips synonym asides (`(syn. T. anguina)`), quoted
cultivar epithets, non-breaking spaces, and holds back anything it cannot reduce
to a plain binomial so a malformed name cannot reach a page title. This class
deliberately does no rewriting of its own.

Two guards:

* **A blank incoming value is never written** — the name is about to become a
  page title, so erasing one would leave a plant untitled.
* **Only `scientific_name` moves.** A spec pins that ownership, visibility and
  the translated fields are untouched.

## Verification

* 7 new specs; full suite **2,360 examples, 0 failures**; rubocop clean across
  747 files.
* Rehearsed against staging: **57 names changed, 0 failures**, then the titles
  exported and applied to ECHOcommunity staging — 1,268 titles changed, none
  blanked, and every plant now carries the same binomial in all five locales.
* Spot-checked rendered pages on staging: published plant pages show the
  binomial; the only blank titles are drafts, which is pre-existing behaviour.