### PR TITLE
Add plants:sync_descriptions for the D-012 acacia text move

### DIFF
--- a/lib/plant_description_sync.rb
+++ b/lib/plant_description_sync.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Writes curated plant narrative text into the API during the plant-data
+# ownership migration.
+#
+# Built for D-012, which moves species-specific descriptions off ECHOcommunity's
+# variety records onto the matching species in the API. The four "Edible
+# Australian Acacias" species all carry the same copied group prose, so
+# *Acacia torulosa* currently describes *Acacia colei*; this replaces each with
+# the paragraph actually written about it. The group-level text it leaves behind
+# moves to a Collection (D-011).
+#
+# Which text belongs to which plant is decided upstream, in the migration
+# workspace, where the reasoning lives with the content. This class applies that
+# decision and composes nothing of its own.
+#
+# Three guards:
+#
+#   * **Only the fields in FIELDS may be written.** A payload naming anything
+#     else is a failure, not a silent skip - this task must never become a
+#     general-purpose writer for a record the API owns.
+#   * **A blank value is never written**, so a description cannot be erased by
+#     an incomplete payload.
+#   * **Only locales named in the payload are touched.** Other translations on
+#     the record are left exactly as they are.
+class PlantDescriptionSync
+  FIELDS = %w[description info_sheet_description].freeze
+
+  Result = Struct.new(:changed, :unchanged, :blank_skipped, :missing_plants,
+                      :failed, :changes, :errors, keyword_init: true)
+
+  def initialize(apply: false)
+    @apply = apply
+  end
+
+  def sync(plants)
+    result = Result.new(changed: 0, unchanged: 0, blank_skipped: 0,
+                        missing_plants: 0, failed: 0, changes: [], errors: [])
+    plants.each { |uuid, by_locale| sync_plant(uuid, by_locale, result) }
+    result
+  end
+
+  private
+
+  def sync_plant(uuid, by_locale, result)
+    plant = Plant.unscoped.find_by(id: uuid)
+    return result.missing_plants += 1 if plant.nil?
+
+    dirty = by_locale.sum { |locale, fields| apply_locale(plant, locale, fields, result) }
+    plant.save! if @apply && dirty.positive?
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "#{uuid}: #{e.class}: #{e.message}"
+  end
+
+  def apply_locale(plant, locale, fields, result)
+    fields.sum do |field, value|
+      unknown = !FIELDS.include?(field)
+      raise ArgumentError, "refusing to write #{field.inspect}" if unknown
+
+      write_field(plant, locale, field, value, result)
+    end
+  end
+
+  def write_field(plant, locale, field, value, result)
+    return (result.blank_skipped += 1) && 0 if value.to_s.strip.empty?
+
+    current = Mobility.with_locale(locale) { plant.public_send(field) }
+    return (result.unchanged += 1) && 0 if current == value
+
+    result.changed += 1
+    result.changes << change_line(plant, locale, field, current, value)
+    Mobility.with_locale(locale) { plant.public_send("#{field}=", value) } if @apply
+    1
+  end
+
+  def change_line(plant, locale, field, current, value)
+    "#{plant.scientific_name} [#{locale}] #{field}: " \
+      "#{current.to_s.length} -> #{value.length} chars"
+  end
+end

--- a/lib/tasks/plant_descriptions.rake
+++ b/lib/tasks/plant_descriptions.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/plant_description_sync')
+
+# Thin wrapper; the reasoning and all three guards live in
+# lib/plant_description_sync.rb.
+#
+#   bin/rails plants:sync_descriptions[tmp/descriptions.json]              # dry run
+#   APPLY=true bin/rails plants:sync_descriptions[tmp/descriptions.json]   # write
+#
+# Payload shape:
+#   {"plants": {"<uuid>": {"en": {"description": "<html>"}}}}
+namespace :plants do
+  desc 'Write curated plant descriptions from a payload (dry run unless APPLY=true)'
+  task :sync_descriptions, [:path] => :environment do |_t, args|
+    path = args[:path] or
+      abort 'usage: bin/rails plants:sync_descriptions[path/to/descriptions.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    payload = JSON.parse(File.read(path))
+    plants = payload['plants'] or abort "no 'plants' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'SYNCING' : 'DRY RUN'} descriptions for #{plants.size} plants"
+    puts "  source: #{payload['source'] || 'unknown'}"
+    puts "  writable fields: #{PlantDescriptionSync::FIELDS.join(', ')}"
+    puts
+
+    result = PlantDescriptionSync.new(apply: apply).sync(plants)
+
+    result.changes.each { |c| puts "    #{c}" }
+    puts if result.changes.any?
+    puts "  fields #{apply ? 'changed' : 'to change'}: #{result.changed}"
+    puts "  already correct: #{result.unchanged}"
+    puts "  blank incoming, skipped: #{result.blank_skipped}"
+    puts "  plants not in this database: #{result.missing_plants}"
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'description sync finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/plant_descriptions_spec.rb
+++ b/spec/tasks/plant_descriptions_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlantDescriptionSync do
+  let(:org) { create(:organization, :real) }
+  let(:plant) do
+    create(:plant, owner_organization_id: org.id, source_organization_id: org.id,
+                   scientific_name: 'Acacia torulosa')
+  end
+
+  def sync(plants, apply: true)
+    described_class.new(apply: apply).sync(plants)
+  end
+
+  before { Mobility.with_locale(:en) { plant.update!(description: 'group prose') } }
+
+  it 'writes the description for the named locale' do
+    result = sync({ plant.id => { 'en' => { 'description' => 'species prose' } } })
+
+    expect(result.changed).to eq 1
+    expect(Mobility.with_locale(:en) { plant.reload.description }).to eq 'species prose'
+  end
+
+  it 'writes info_sheet_description too' do
+    result = sync({ plant.id => { 'en' => { 'info_sheet_description' => 'sheet text' } } })
+
+    expect(result.changed).to eq 1
+    expect(Mobility.with_locale(:en) { plant.reload.info_sheet_description })
+      .to eq 'sheet text'
+  end
+
+  # This must never become a general-purpose writer for a record the API owns.
+  it 'refuses to write a field outside the allowlist' do
+    result = sync({ plant.id => { 'en' => { 'scientific_name' => 'Nope' } } })
+
+    expect(result.failed).to eq 1
+    expect(result.errors.first).to include 'refusing to write'
+    expect(plant.reload.scientific_name).to eq 'Acacia torulosa'
+  end
+
+  it 'never erases text with a blank value' do
+    result = sync({ plant.id => { 'en' => { 'description' => '  ' } } })
+
+    expect(result.blank_skipped).to eq 1
+    expect(result.changed).to eq 0
+    expect(Mobility.with_locale(:en) { plant.reload.description }).to eq 'group prose'
+  end
+
+  it 'leaves locales the payload does not name alone' do
+    Mobility.with_locale(:fr) { plant.update!(description: 'texte') }
+
+    sync({ plant.id => { 'en' => { 'description' => 'species prose' } } })
+
+    expect(Mobility.with_locale(:fr) { plant.reload.description }).to eq 'texte'
+  end
+
+  it 'reports a plant that is not in this database instead of failing' do
+    result = sync({ SecureRandom.uuid => { 'en' => { 'description' => 'x' } } })
+
+    expect(result.missing_plants).to eq 1
+    expect(result.failed).to eq 0
+  end
+
+  it 'counts an already-correct value as unchanged' do
+    result = sync({ plant.id => { 'en' => { 'description' => 'group prose' } } })
+
+    expect(result.unchanged).to eq 1
+    expect(result.changed).to eq 0
+  end
+
+  it 'changes nothing on a dry run but still reports what would change' do
+    result = sync({ plant.id => { 'en' => { 'description' => 'species prose' } } },
+                  apply: false)
+
+    expect(result.changed).to eq 1
+    expect(result.changes.first).to include 'Acacia torulosa'
+    expect(Mobility.with_locale(:en) { plant.reload.description }).to eq 'group prose'
+  end
+end


### PR DESCRIPTION
Writes curated plant narrative text into the API.

## Why

**D-012** moves the species-specific description off each ECHOcommunity variety
record onto the matching species in the Plant API, replacing the copied group
text. All four "Edible Australian Acacias" records currently carry the same
five-paragraph group prose, which is why ***Acacia torulosa* describes *Acacia
colei***. The group-level text left behind moves to a Collection (D-011).

## Guards

* **Only `description` and `info_sheet_description` may be written.** A payload
  naming any other field **raises** rather than skipping silently — this task
  must never become a general-purpose writer for a record the API owns.
* **A blank value is never written**, so an incomplete payload cannot erase text.
* **Only locales named in the payload are touched.**

## On the content

The paragraphs are not retyped. `tools/build_acacia_split.py` reads the API's
own `description` on the colei record, splits it on the binomial each paragraph
opens with, and emits one paragraph per species. Every sentence already exists
in the API.

They were then checked against the four ECHOcommunity variety records D-012
names, and all four are **byte-exact** — 253, 378, 172 and 238 characters of
plain text respectively. D-012's requirement that the same text not appear in
both the Collection and the species pages is satisfied by construction: the
split is a partition.

Scope note: only the English `description` moves. `info_sheet_description` is
genuinely group-level prose — it names *A. corriacea*, *A. ampliceps*,
*A. victoriae* and *A. stenophylla*, which are not in this set — and D-010
explicitly accepts leaving it. The colei record's `fr` "translation" turns out
to be English text stored under the French locale, so it is left alone and
logged as a separate data-quality item.

## Verification

8 specs, all passing; rubocop clean.