### PR TITLE
Add the Köppen-Geiger climate zones and plant assignments (D-017)

### DIFF
--- a/app/graphql/resolvers/koppen_zones_resolver.rb
+++ b/app/graphql/resolvers/koppen_zones_resolver.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'search_object'
+require 'search_object/plugin/graphql'
+
+module Resolvers
+  # Populates the data for the koppenZones Query
+  class KoppenZonesResolver < Resolvers::BaseResolver
+    include SearchObject.module(:graphql)
+    type Types::KoppenZoneType::KoppenZoneConnectionWithTotalCountType, null: false
+    description 'Returns a list of Köppen-Geiger climate zones'
+
+    # Ordered by `position`, which encodes the classification's own sequence
+    # (groups, then subgroups, then classes) rather than alphabetical order, so
+    # a client rendering the tree does not have to re-sort. id breaks ties so
+    # the offset-paginated connection cannot skip or repeat a row between
+    # pages, matching the other lookup resolvers.
+    scope { KoppenZone.all.order(:position).order(:id) }
+
+    option :language,
+           type: String,
+           with: :apply_language_filter,
+           description: 'Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.'
+    option :code,
+           type: String,
+           with: :apply_code_filter,
+           description: 'Exact, case-insensitive match on the Köppen code'
+    option :level,
+           type: String,
+           with: :apply_level_filter,
+           description: 'Restrict to group, subgroup or class'
+    option :authoritative,
+           type: Boolean,
+           with: :apply_authoritative_filter,
+           description: 'Restrict to zones that do (true) or do not (false) appear in ' \
+                        'Beck et al. 2018'
+
+    def apply_code_filter(scope, value)
+      return scope if value.blank?
+
+      scope.where('lower(code) = ?', value.downcase)
+    end
+
+    def apply_level_filter(scope, value)
+      return scope if value.blank?
+
+      scope.where(level: value)
+    end
+
+    def apply_authoritative_filter(scope, value)
+      return scope if value.nil?
+
+      scope.where(authoritative: value)
+    end
+  end
+end

--- a/app/graphql/types/koppen_zone_type.rb
+++ b/app/graphql/types/koppen_zone_type.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Types
+  # Defines fields for a Köppen-Geiger climate zone.
+  class KoppenZoneType < Types::BaseObject
+    global_id_field :id
+    implements GraphQL::Types::Relay::Node
+
+    description 'A Köppen-Geiger climate zone. The list is fixed; only the ' \
+                'translated name and description are editable.'
+
+    field :uuid, ID,
+          description: 'The internal database ID for a climate zone',
+          null: false,
+          method: :id
+    field :code, String,
+          description: 'The Köppen code, for example Cfa. Not translated: codes are ' \
+                       'defined by the classification and do not change.',
+          null: false
+    field :level, String,
+          description: 'group (A-E), subgroup (Cf, BS, ...) or class (Cfa, BSh, ...)',
+          null: false
+    field :authoritative, Boolean,
+          description: 'True when this zone appears in Beck et al. 2018, the published ' \
+                       'map legend: the 5 groups and 30 classes. The 8 subgroups are an ' \
+                       'ECHO intermediate level, and BSn/BWn record frequent fog, which ' \
+                       'map rasters do not resolve. False is a statement about the map ' \
+                       'product, not about legitimacy.',
+          null: false
+    field :parent, Types::KoppenZoneType,
+          description: 'The zone one level up: Cfa -> Cf -> C',
+          null: true
+    field :children, [Types::KoppenZoneType],
+          description: 'The zones one level down',
+          null: false
+    field :classification_source, String,
+          description: 'The classification this row was modelled on',
+          null: false
+    field :classification_version, String,
+          description: 'The source release this row was loaded from',
+          null: false
+    field :snapshot_date, GraphQL::Types::ISO8601Date,
+          description: 'The date of the source release',
+          null: false
+    field :name, String,
+          description: 'The translated name of a climate zone',
+          null: true
+    field :description, String,
+          description: 'The translated description of a climate zone',
+          null: true
+    field :translations, [Types::KoppenZoneType::KoppenZoneTranslationType],
+          description: 'Translations of translatable climate zone fields',
+          null: false,
+          method: :translations_array
+
+    # Ordered so a client rendering the tree gets a stable sequence without
+    # sorting client-side; id breaks ties as elsewhere.
+    def children
+      object.children.order(:position).order(:id)
+    end
+  end
+end

--- a/app/graphql/types/koppen_zone_type/koppen_zone_connection_with_total_count_type.rb
+++ b/app/graphql/types/koppen_zone_type/koppen_zone_connection_with_total_count_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  class KoppenZoneType
+    # Adds a total_count field to the climate zone connection
+    class KoppenZoneConnectionWithTotalCountType < GraphQL::Types::Relay::BaseConnection
+      edge_type(KoppenZoneEdgeType)
+
+      field :total_count, Integer, null: false
+      def total_count
+        object.items.size
+      end
+    end
+  end
+end

--- a/app/graphql/types/koppen_zone_type/koppen_zone_edge_type.rb
+++ b/app/graphql/types/koppen_zone_type/koppen_zone_edge_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class KoppenZoneType
+    # The edge type for the climate zone type
+    class KoppenZoneEdgeType < GraphQL::Types::Relay::BaseEdge
+      node_type(Types::KoppenZoneType)
+    end
+  end
+end

--- a/app/graphql/types/koppen_zone_type/koppen_zone_translation_type.rb
+++ b/app/graphql/types/koppen_zone_type/koppen_zone_translation_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class KoppenZoneType
+    # Defines translated fields for a climate zone
+    class KoppenZoneTranslationType < Types::BaseObject
+      description 'Translated fields for a climate zone'
+      field :locale, String,
+            description: 'The locale for this translation',
+            null: false
+      field :name, String,
+            description: 'The translated name of a climate zone',
+            null: true
+      field :description, String,
+            description: 'The translated description of a climate zone',
+            null: true
+    end
+  end
+end

--- a/app/graphql/types/plant_type.rb
+++ b/app/graphql/types/plant_type.rb
@@ -34,6 +34,13 @@ module Types
           description: 'A list of categories to which a plant belongs',
           null: true,
           connection: true
+    field :koppen_zones, Types::KoppenZoneType::KoppenZoneConnectionWithTotalCountType,
+          description: 'The Köppen-Geiger climate zones a plant is suited to. Most ' \
+                       'assignments sit at the subgroup level (Cf, BS) rather than a ' \
+                       'full class, which records what is known without asserting a ' \
+                       'summer-temperature class.',
+          null: true,
+          connection: true
     field :varieties, Types::VarietyType::VarietyConnectionWithTotalCountType,
           null: true,
           connection: true

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -38,6 +38,7 @@ module Types
     field :antinutrients, resolver: Resolvers::AntinutrientsResolver, connection: true
     field :tolerances, resolver: Resolvers::TolerancesResolver, connection: true
     field :growth_habits, resolver: Resolvers::GrowthHabitsResolver, connection: true
+    field :koppen_zones, resolver: Resolvers::KoppenZonesResolver, connection: true
     field :plants, resolver: Resolvers::PlantsResolver, connection: true
     field :varieties, resolver: Resolvers::VarietiesResolver, connection: true
     field :specimens, resolver: Resolvers::SpecimensResolver, connection: true

--- a/app/models/koppen_zone.rb
+++ b/app/models/koppen_zone.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# A Köppen-Geiger climate zone (D-017).
+#
+# The LIST is locked: rows may only be created or destroyed inside
+# KoppenZone.importing, the same arrangement as Family. Everything ECHO adds on
+# top - the translated name and description - is ordinary editable data.
+#
+# Three levels, self-parented:
+#
+#   group      5 rows   A B C D E
+#   subgroup   8 rows   BS BW Cf Cs Cw Df Ds Dw
+#   class     32 rows   the 30 published classes, plus BSn and BWn
+#
+# The subgroup level is not part of the published classification. It is kept
+# because it carries 306 of ECHOcommunity's 512 existing assignments: a plant
+# recorded as `Cf` is stating what is known without asserting a
+# summer-temperature class, and deciding whether it means Cfa, Cfb or Cfc is an
+# agronomic judgement rather than a lookup. `authoritative` marks the 30
+# published classes so that distinction stays legible instead of being
+# flattened away.
+#
+# BSn and BWn are kept too. They were first taken for ECHO inventions; `n` is a
+# recognised third letter meaning frequent fog (Lima, Walvis Bay), absent from
+# the Beck 2018 map only because rasters do not resolve fog.
+#
+# The natural key is `code`. Codes are defined by the classification and do not
+# change; the names ECHO puts on them do.
+class KoppenZone < ApplicationRecord
+  # Raised when something tries to add to or remove from the locked list.
+  class ImmutableListError < StandardError; end
+
+  IMPORT_FLAG = 'koppen_zones.import_mode'
+
+  LEVELS = %w[group subgroup class].freeze
+
+  extend Mobility
+  translates :name, :description
+
+  # Registered before the associations so the immutability guard fires first -
+  # has_many ... dependent: registers its own before_destroy at the point it is
+  # declared. See Family for the incident that established this ordering.
+  before_create :assert_importing!
+  before_destroy :assert_importing!
+
+  belongs_to :parent, class_name: 'KoppenZone', optional: true
+  has_many :children, class_name: 'KoppenZone', foreign_key: :parent_id,
+                      inverse_of: :parent, dependent: :restrict_with_error
+
+  validates :code, :level, :classification_source, :classification_version,
+            :snapshot_date, presence: true
+  validates :level, inclusion: { in: LEVELS }
+  validate :parent_must_not_be_self
+
+  scope :groups, -> { where(level: 'group') }
+  scope :subgroups, -> { where(level: 'subgroup') }
+  scope :classes, -> { where(level: 'class') }
+  scope :authoritative, -> { where(authoritative: true) }
+  scope :ordered, -> { order(:position, :code) }
+
+  class << self
+    # The only context in which the list itself may change. Mirrors
+    # Family.importing, including the explicit reset in the ensure: a
+    # transaction-local setting lives until the end of the ENCLOSING
+    # transaction, so under transactional fixtures the list would otherwise
+    # stay unlocked for the rest of any example that imported once, and the
+    # trigger specs would pass without proving anything.
+    def importing
+      previous = Thread.current[:koppen_zone_importing]
+      Thread.current[:koppen_zone_importing] = true
+      transaction do
+        connection.execute("SELECT set_config('#{IMPORT_FLAG}', 'on', true)")
+        yield
+      end
+    ensure
+      Thread.current[:koppen_zone_importing] = previous
+      connection.execute("SELECT set_config('#{IMPORT_FLAG}', 'off', true)") if connection.transaction_open?
+    end
+
+    def importing?
+      Thread.current[:koppen_zone_importing] == true
+    end
+  end
+
+  # The chain up to the group, nearest first: Cfa -> Cf -> C.
+  def ancestry
+    node = parent
+    chain = []
+    while node
+      chain << node
+      node = node.parent
+    end
+    chain
+  end
+
+  def translations_array
+    translations.map do |language, attributes|
+      { locale: language, name: attributes['name'],
+        description: attributes['description'] }
+    end
+  end
+
+  private
+
+  def parent_must_not_be_self
+    errors.add(:parent, 'cannot be the zone itself') if parent_id.present? && parent_id == id
+  end
+
+  def assert_importing!
+    return if self.class.importing?
+
+    raise ImmutableListError,
+          'koppen_zones is a locked reference list; use KoppenZone.importing for imports'
+  end
+end

--- a/app/models/koppen_zones_plant.rb
+++ b/app/models/koppen_zones_plant.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Relation table for Köppen climate zones and Plants
+class KoppenZonesPlant < ApplicationRecord
+  include VersionedUnderRoot
+
+  belongs_to :koppen_zone
+  belongs_to :plant
+
+  versioned_under_root { ['Plant', plant_id] }
+end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -22,6 +22,9 @@ class Plant < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :growth_habits_plants, dependent: :destroy
   has_many :growth_habits, through: :growth_habits_plants, dependent: :destroy
 
+  has_many :koppen_zones_plants, dependent: :destroy
+  has_many :koppen_zones, through: :koppen_zones_plants, dependent: :destroy
+
   has_many :tolerances_plants, dependent: :destroy
   has_many :tolerances, through: :tolerances_plants, dependent: :destroy
 

--- a/db/migrate/20260814000001_create_koppen_zones.rb
+++ b/db/migrate/20260814000001_create_koppen_zones.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# The Köppen-Geiger climate-zone lookup (D-017), modelled on families.
+#
+# Three levels, self-parented: 5 groups, 8 subgroups and 30 classes, plus the
+# two `n` fog variants ECHOcommunity already uses - 45 rows. The subgroup level
+# (`Cf`, `BS`, ...) is not part of the published classification, but it carries
+# 306 of ECHOcommunity's 512 existing assignments: recording a plant as `Cf`
+# states what is known without asserting a summer-temperature class it does not
+# have. `authoritative` marks the 30 published classes so the distinction stays
+# visible rather than being flattened away.
+#
+# `code` is the natural key, as `name` is for families. Codes are defined by the
+# classification and do not change; the translated names on top are ECHO's and
+# do.
+class CreateKoppenZones < ActiveRecord::Migration[8.1]
+  def change
+    create_table :koppen_zones, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+      t.string :code, null: false
+      t.string :level, null: false
+      t.references :parent, type: :uuid, foreign_key: { to_table: :koppen_zones }
+      t.boolean :authoritative, null: false, default: false
+      t.string :classification_source, null: false
+      t.string :classification_version, null: false
+      t.date :snapshot_date, null: false
+      t.integer :position
+      t.jsonb :translations, default: {}, null: false
+      t.timestamps
+    end
+
+    # Codes are case-significant in the classification (`Cfa` not `CFA`), but a
+    # unique index on the exact string is what protects the natural key; the
+    # lower() index additionally stops `cfa` and `Cfa` coexisting.
+    add_index :koppen_zones, 'lower(code)', unique: true,
+                                            name: 'index_koppen_zones_on_lower_code'
+    add_index :koppen_zones, :level
+    add_index :koppen_zones, :authoritative
+
+    # Database-level immutability, exactly as for families: a model callback
+    # alone is bypassed by insert_all, delete_all and a console session.
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          CREATE FUNCTION koppen_zones_reject_list_change() RETURNS trigger AS $$
+          BEGIN
+            IF current_setting('koppen_zones.import_mode', true) IS DISTINCT FROM 'on' THEN
+              RAISE EXCEPTION
+                'koppen_zones is a locked reference list; % is only permitted during an import',
+                TG_OP;
+            END IF;
+            -- Branch on TG_OP rather than COALESCE(NEW, OLD): NEW is unassigned
+            -- during a DELETE and OLD during an INSERT, and merely referencing
+            -- the unassigned side raises before COALESCE can evaluate it. This
+            -- is the bug families migration 3 had to go back and fix.
+            IF TG_OP = 'DELETE' THEN
+              RETURN OLD;
+            ELSE
+              RETURN NEW;
+            END IF;
+          END;
+          $$ LANGUAGE plpgsql;
+
+          CREATE TRIGGER koppen_zones_locked_list
+            BEFORE INSERT OR DELETE ON koppen_zones
+            FOR EACH ROW EXECUTE PROCEDURE koppen_zones_reject_list_change();
+        SQL
+      end
+      dir.down do
+        execute <<~SQL
+          DROP TRIGGER IF EXISTS koppen_zones_locked_list ON koppen_zones;
+          DROP FUNCTION IF EXISTS koppen_zones_reject_list_change();
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260814000002_create_koppen_zones_plants.rb
+++ b/db/migrate/20260814000002_create_koppen_zones_plants.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# The plant-to-climate-zone join (D-017), matching categories_plants.
+#
+# ECHOcommunity holds 512 of these. Its own join table has no foreign keys and
+# no unique index, which is how it came to contain one row pointing at a zone
+# that does not exist; both constraints are present here.
+class CreateKoppenZonesPlants < ActiveRecord::Migration[8.1]
+  def change
+    create_table :koppen_zones_plants, id: :uuid do |t|
+      t.references :koppen_zone, null: false, foreign_key: true, type: :uuid
+      t.references :plant, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+    add_index :koppen_zones_plants, %i[koppen_zone_id plant_id], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,7 +1,6 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -390,6 +390,19 @@ CREATE TABLE public.koppen_zones (
 
 
 --
+-- Name: koppen_zones_plants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.koppen_zones_plants (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    koppen_zone_id uuid NOT NULL,
+    plant_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: life_cycle_events; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -872,6 +885,14 @@ ALTER TABLE ONLY public.koppen_zones
 
 
 --
+-- Name: koppen_zones_plants koppen_zones_plants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.koppen_zones_plants
+    ADD CONSTRAINT koppen_zones_plants_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: life_cycle_events life_cycle_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1247,6 +1268,27 @@ CREATE UNIQUE INDEX index_koppen_zones_on_lower_code ON public.koppen_zones USIN
 --
 
 CREATE INDEX index_koppen_zones_on_parent_id ON public.koppen_zones USING btree (parent_id);
+
+
+--
+-- Name: index_koppen_zones_plants_on_koppen_zone_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_koppen_zones_plants_on_koppen_zone_id ON public.koppen_zones_plants USING btree (koppen_zone_id);
+
+
+--
+-- Name: index_koppen_zones_plants_on_koppen_zone_id_and_plant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_koppen_zones_plants_on_koppen_zone_id_and_plant_id ON public.koppen_zones_plants USING btree (koppen_zone_id, plant_id);
+
+
+--
+-- Name: index_koppen_zones_plants_on_plant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_koppen_zones_plants_on_plant_id ON public.koppen_zones_plants USING btree (plant_id);
 
 
 --
@@ -1901,6 +1943,14 @@ ALTER TABLE ONLY public.common_names
 
 
 --
+-- Name: koppen_zones_plants fk_rails_e2dd31b318; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.koppen_zones_plants
+    ADD CONSTRAINT fk_rails_e2dd31b318 FOREIGN KEY (koppen_zone_id) REFERENCES public.koppen_zones(id);
+
+
+--
 -- Name: image_attributes_images fk_rails_e3ccc8f28f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1922,6 +1972,14 @@ ALTER TABLE ONLY public.tolerances_varieties
 
 ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT fk_rails_efc215b305 FOREIGN KEY (principal_id) REFERENCES public.principals(id);
+
+
+--
+-- Name: koppen_zones_plants fk_rails_fcdfb0822a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.koppen_zones_plants
+    ADD CONSTRAINT fk_rails_fcdfb0822a FOREIGN KEY (plant_id) REFERENCES public.plants(id);
 
 
 --
@@ -2019,6 +2077,7 @@ ALTER TABLE ONLY public.varieties
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260814000002'),
 ('20260814000001'),
 ('20260807000001'),
 ('20260806000003'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -8,13 +9,6 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
 
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
@@ -115,7 +109,35 @@ END;
 $$;
 
 
+--
+-- Name: koppen_zones_reject_list_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.koppen_zones_reject_list_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF current_setting('koppen_zones.import_mode', true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION
+      'koppen_zones is a locked reference list; % is only permitted during an import',
+      TG_OP;
+  END IF;
+  -- Branch on TG_OP rather than COALESCE(NEW, OLD): NEW is unassigned
+  -- during a DELETE and OLD during an INSERT, and merely referencing
+  -- the unassigned side raises before COALESCE can evaluate it. This
+  -- is the bug families migration 3 had to go back and fix.
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+
 SET default_tablespace = '';
+
+SET default_table_access_method = heap;
 
 --
 -- Name: antinutrients; Type: TABLE; Schema: public; Owner: -
@@ -342,6 +364,26 @@ CREATE TABLE public.images (
     visibility integer DEFAULT 0 NOT NULL,
     imageable_type character varying NOT NULL,
     imageable_id uuid NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: koppen_zones; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.koppen_zones (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    code character varying NOT NULL,
+    level character varying NOT NULL,
+    parent_id uuid,
+    authoritative boolean DEFAULT false NOT NULL,
+    classification_source character varying NOT NULL,
+    classification_version character varying NOT NULL,
+    snapshot_date date NOT NULL,
+    "position" integer,
+    translations jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -822,6 +864,14 @@ ALTER TABLE ONLY public.images
 
 
 --
+-- Name: koppen_zones koppen_zones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.koppen_zones
+    ADD CONSTRAINT koppen_zones_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: life_cycle_events life_cycle_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1172,6 +1222,34 @@ CREATE INDEX index_images_on_visibility ON public.images USING btree (visibility
 
 
 --
+-- Name: index_koppen_zones_on_authoritative; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_koppen_zones_on_authoritative ON public.koppen_zones USING btree (authoritative);
+
+
+--
+-- Name: index_koppen_zones_on_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_koppen_zones_on_level ON public.koppen_zones USING btree (level);
+
+
+--
+-- Name: index_koppen_zones_on_lower_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_koppen_zones_on_lower_code ON public.koppen_zones USING btree (lower((code)::text));
+
+
+--
+-- Name: index_koppen_zones_on_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_koppen_zones_on_parent_id ON public.koppen_zones USING btree (parent_id);
+
+
+--
 -- Name: index_life_cycle_events_on_location_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1476,7 +1554,14 @@ CREATE INDEX index_versions_on_metadata_jsonb_path_ops ON public.versions USING 
 -- Name: families families_locked_list; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER families_locked_list BEFORE INSERT OR DELETE ON public.families FOR EACH ROW EXECUTE PROCEDURE public.families_reject_list_change();
+CREATE TRIGGER families_locked_list BEFORE INSERT OR DELETE ON public.families FOR EACH ROW EXECUTE FUNCTION public.families_reject_list_change();
+
+
+--
+-- Name: koppen_zones koppen_zones_locked_list; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER koppen_zones_locked_list BEFORE INSERT OR DELETE ON public.koppen_zones FOR EACH ROW EXECUTE FUNCTION public.koppen_zones_reject_list_change();
 
 
 --
@@ -1621,6 +1706,14 @@ ALTER TABLE ONLY public.antinutrients_plants
 
 ALTER TABLE ONLY public.record_drafts
     ADD CONSTRAINT fk_rails_0fd32e2aef FOREIGN KEY (last_editor_principal_id) REFERENCES public.principals(id);
+
+
+--
+-- Name: koppen_zones fk_rails_12de8bfba0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.koppen_zones
+    ADD CONSTRAINT fk_rails_12de8bfba0 FOREIGN KEY (parent_id) REFERENCES public.koppen_zones(id);
 
 
 --
@@ -1926,6 +2019,7 @@ ALTER TABLE ONLY public.varieties
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260814000001'),
 ('20260807000001'),
 ('20260806000003'),
 ('20260806000002'),

--- a/lib/ec_koppen_zone_importer.rb
+++ b/lib/ec_koppen_zone_importer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Applies ECHOcommunity's plant-to-climate-zone assignments to the API (D-017).
+#
+# ECHOcommunity holds 512 of them across 45 zones, entered against the GMCC
+# selector since 2017. They are the reason the zone lookup exists: without them
+# the selector cannot be migrated.
+#
+# Zones are matched by `code`, not by id. ECHOcommunity's ids are integers on an
+# un-foreign-keyed table whose rows have been deleted before - the parent ids
+# are non-contiguous - so the code is the only identifier meaningful across both
+# systems.
+#
+# Additive. A zone ECHOcommunity no longer lists is left in place: removing an
+# assignment is an editorial act, not a migration one, and the same reasoning
+# the common-name sync follows.
+#
+# Two guards:
+#
+#   * **An unknown zone code is reported, never created.** koppen_zones is a
+#     locked list; a code that is not in it means the seed and the payload
+#     disagree, which is a fault to surface rather than paper over.
+#   * **A plant not in this database is counted and skipped**, so a partial
+#     payload cannot fail the run.
+class EcKoppenZoneImporter
+  Result = Struct.new(:linked, :present, :missing_plants, :unknown_zones,
+                      :failed, :errors, keyword_init: true)
+
+  def initialize(apply: false)
+    @apply = apply
+  end
+
+  def import(plants)
+    result = Result.new(linked: 0, present: 0, missing_plants: 0,
+                        unknown_zones: [], failed: 0, errors: [])
+    zones = KoppenZone.all.index_by { |z| z.code.downcase }
+    plants.each { |uuid, codes| link(uuid, Array(codes), zones, result) }
+    result.unknown_zones.uniq!
+    result
+  end
+
+  private
+
+  def link(uuid, codes, zones, result)
+    plant = Plant.unscoped.find_by(id: uuid)
+    return result.missing_plants += 1 if plant.nil?
+
+    existing = plant.koppen_zones_plants.pluck(:koppen_zone_id).to_set
+    codes.each { |code| link_one(plant, code, zones, existing, result) }
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "#{uuid}: #{e.class}: #{e.message}"
+  end
+
+  def link_one(plant, code, zones, existing, result)
+    zone = zones[code.to_s.downcase]
+    if zone.nil?
+      result.unknown_zones << code
+      return
+    end
+    return result.present += 1 if existing.include?(zone.id)
+
+    result.linked += 1
+    return unless @apply
+
+    KoppenZonesPlant.create!(plant: plant, koppen_zone: zone)
+    existing << zone.id
+  end
+end

--- a/lib/koppen_zone_data.rb
+++ b/lib/koppen_zone_data.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# The Köppen-Geiger climate zone list (D-017).
+#
+# 45 rows in three self-parented levels. The names are ECHOcommunity's, because
+# they are what the GMCC selector shows today and continuity matters more than
+# matching a paper's wording - `D` is "Continental" here and "Cold" in Beck,
+# both in common use. Three genuine errors in those names are corrected on the
+# way in: "Climante", "Clomate", and a double space in the Dsa name.
+#
+# `authoritative` means "appears in Beck et al. 2018", the machine-readable map
+# legend: the 5 groups and the 30 classes, but not the 8 subgroups, which are
+# ECHO's own intermediate level, nor BSn/BWn. The `n` third letter (frequent
+# fog - Lima, Walvis Bay) is recognised in the classical scheme; it is absent
+# from Beck only because map rasters do not resolve fog. So `authoritative` is a
+# statement about the map product, not about legitimacy.
+#
+# Kept apart from KoppenZoneSeeder so the table can be read, reviewed and
+# diffed as data, without the seeding logic wrapped around it.
+module KoppenZoneData
+  SOURCE = 'Köppen–Geiger classical scheme'
+  VERSION = 'Beck et al. 2018, Scientific Data 5:180214'
+  SNAPSHOT = Date.new(2018, 10, 30)
+
+  # code, parent, in Beck 2018?, name
+  GROUPS = [
+    ['A', nil, true, 'Tropical Climate'],
+    ['B', nil, true, 'Arid Climate'],
+    ['C', nil, true, 'Temperate Climate'],
+    ['D', nil, true, 'Continental Climate'],
+    ['E', nil, true, 'Polar Climate']
+  ].freeze
+
+  SUBGROUPS = [
+    ['BS', 'B', false, 'Arid Steppe Climate'],
+    ['BW', 'B', false, 'Arid Desert Climate'],
+    ['Cf', 'C', false, 'Temperate Climate without Dry Season'],
+    ['Cs', 'C', false, 'Temperate Climate with Dry Summer'],
+    ['Cw', 'C', false, 'Temperate Climate with Dry Winter'],
+    ['Df', 'D', false, 'Continental Climate without Dry Season'],
+    ['Ds', 'D', false, 'Continental Climate with Dry Summer'],
+    ['Dw', 'D', false, 'Continental Climate with Dry Winter']
+  ].freeze
+
+  CLASSES = [
+    ['Af',  'A',  true,  'Tropical Rainforest Climate'],
+    ['Am',  'A',  true,  'Tropical Monsoon Climate'],
+    ['Aw',  'A',  true,  'Tropical Savanna Climate'],
+    ['BSh', 'BS', true,  'Hot Arid Steppe Climate'],
+    ['BSk', 'BS', true,  'Cold Arid Steppe Climate'],
+    ['BSn', 'BS', false, 'Mild Arid Steppe Climate'],       # was "Climante"
+    ['BWh', 'BW', true,  'Hot Arid Desert Climate'],
+    ['BWk', 'BW', true,  'Cold Arid Desert Climate'],
+    ['BWn', 'BW', false, 'Mild Arid Desert Climate'],       # was "Clomate"
+    ['Cfa', 'Cf', true,  'Temperate Climate without Dry Season with Hot Summer'],
+    ['Cfb', 'Cf', true,  'Temperate Climate without Dry Season with Warm Summer'],
+    ['Cfc', 'Cf', true,  'Temperate Climate without Dry Season with Cold Summer'],
+    ['Csa', 'Cs', true,  'Temperate Climate with Hot Dry Summer'],
+    ['Csb', 'Cs', true,  'Temperate Climate with Warm Dry Summer'],
+    ['Csc', 'Cs', true,  'Temperate Climate with Cold Dry Summer'],
+    ['Cwa', 'Cw', true,  'Temperate Climate with Dry Winter and Hot Summer'],
+    ['Cwb', 'Cw', true,  'Temperate Climate with Dry Winter and Warm Summer'],
+    ['Cwc', 'Cw', true,  'Temperate Climate with Dry Winter and Cold Summer'],
+    ['Dfa', 'Df', true,  'Continental Climate without Dry Season with Hot Summer'],
+    ['Dfb', 'Df', true,  'Continental Climate without Dry Season with Warm Summer'],
+    ['Dfc', 'Df', true,  'Continental Climate without Dry Season with Cold Summer'],
+    ['Dfd', 'Df', true,  'Continental Climate without Dry Season with Very Cold Winter'],
+    ['Dsa', 'Ds', true,  'Continental Climate with Hot Dry Summer'], # had a double space
+    ['Dsb', 'Ds', true,  'Continental Climate with Warm Dry Summer'],
+    ['Dsc', 'Ds', true,  'Continental Climate with Cold Dry Summer'],
+    ['Dsd', 'Ds', true,  'Continental Climate with Dry Summer and Very Cold Winter'],
+    ['Dwa', 'Dw', true,  'Continental Climate with Dry Winter and Hot Summer'],
+    ['Dwb', 'Dw', true,  'Continental Climate with Dry Winter and Warm Summer'],
+    ['Dwc', 'Dw', true,  'Continental Climate with Dry Winter and Cold Summer'],
+    ['Dwd', 'Dw', true,  'Continental Climate with Very Cold Dry Winter'],
+    ['EF',  'E',  true,  'Eternal Winter'],
+    ['ET',  'E',  true,  'Tundra']
+  ].freeze
+
+  ALL = (GROUPS.map { |r| r + ['group'] } +
+         SUBGROUPS.map { |r| r + ['subgroup'] } +
+         CLASSES.map { |r| r + ['class'] }).freeze
+end

--- a/lib/koppen_zone_seeder.rb
+++ b/lib/koppen_zone_seeder.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/koppen_zone_data')
+
+# Seeds the Köppen-Geiger climate zones (D-017). The list itself, and the
+# reasoning behind which rows exist, is in lib/koppen_zone_data.rb.
+#
+# Idempotent: re-seeding updates the structural columns and leaves any English
+# name a curator has since edited alone, since the name lives in the editable
+# translated layer.
+class KoppenZoneSeeder
+  include KoppenZoneData
+
+  ALL = KoppenZoneData::ALL
+  SOURCE = KoppenZoneData::SOURCE
+  VERSION = KoppenZoneData::VERSION
+  SNAPSHOT = KoppenZoneData::SNAPSHOT
+
+  Result = Struct.new(:created, :updated, :unchanged, keyword_init: true)
+
+  def initialize(apply: false)
+    @apply = apply
+  end
+
+  def seed
+    result = Result.new(created: 0, updated: 0, unchanged: 0)
+    KoppenZone.importing do
+      # Two passes: every parent must exist before a child can reference it.
+      ALL.each { |code, _p, auth, name, level| upsert(code, level, auth, name, result) }
+      link_parents if @apply
+    end
+    result
+  end
+
+  private
+
+  def upsert(code, level, authoritative, name, result)
+    zone = KoppenZone.find_by(code: code)
+    attrs = structural_attrs(code, level, authoritative)
+    return create_zone(code, attrs, name, result) if zone.nil?
+
+    if attrs.any? { |k, v| zone.public_send(k) != v }
+      result.updated += 1
+      zone.update!(attrs) if @apply
+    else
+      result.unchanged += 1
+    end
+  end
+
+  # Everything the classification fixes. The name is deliberately absent: it
+  # lives in the editable translated layer, so a re-seed must not overwrite a
+  # curator's wording.
+  def structural_attrs(code, level, authoritative)
+    { level: level, authoritative: authoritative,
+      classification_source: SOURCE, classification_version: VERSION,
+      snapshot_date: SNAPSHOT, position: ALL.index { |r| r[0] == code } }
+  end
+
+  def create_zone(code, attrs, name, result)
+    result.created += 1
+    return unless @apply
+
+    zone = KoppenZone.new(attrs.merge(code: code))
+    Mobility.with_locale(:en) { zone.name = name }
+    zone.save!
+  end
+
+  def link_parents
+    by_code = KoppenZone.all.index_by(&:code)
+    ALL.each do |code, parent_code, _auth, _name, _level|
+      next if parent_code.nil?
+
+      zone = by_code[code] or next
+      parent = by_code[parent_code] or next
+      zone.update!(parent_id: parent.id) unless zone.parent_id == parent.id
+    end
+  end
+end

--- a/lib/tasks/koppen_zones.rake
+++ b/lib/tasks/koppen_zones.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/koppen_zone_seeder')
+
+# Seeds the Köppen-Geiger climate zones. The list and its reasoning live in
+# lib/koppen_zone_seeder.rb.
+#
+#   bin/rails koppen:seed              # dry run
+#   APPLY=true bin/rails koppen:seed   # write
+#
+# Idempotent: safe to re-run after a deploy.
+namespace :koppen do
+  desc 'Seed the Köppen climate zone lookup (dry run unless APPLY=true)'
+  task seed: :environment do
+    apply = ENV['APPLY'] == 'true'
+    puts "#{apply ? 'SEEDING' : 'DRY RUN'} #{KoppenZoneSeeder::ALL.size} Köppen zones"
+    puts "  source:  #{KoppenZoneSeeder::SOURCE}"
+    puts "  version: #{KoppenZoneSeeder::VERSION}"
+    puts
+
+    result = KoppenZoneSeeder.new(apply: apply).seed
+
+    puts "  zones #{apply ? 'created' : 'to create'}: #{result.created}"
+    puts "  zones #{apply ? 'updated' : 'to update'}: #{result.updated}"
+    puts "  already correct: #{result.unchanged}"
+    next unless apply
+
+    puts
+    puts "  groups:    #{KoppenZone.groups.count}"
+    puts "  subgroups: #{KoppenZone.subgroups.count}"
+    puts "  classes:   #{KoppenZone.classes.count}"
+    puts "  in Beck 2018: #{KoppenZone.authoritative.count}"
+    orphans = KoppenZone.where(parent_id: nil).where.not(level: 'group').count
+    puts "  non-group zones without a parent: #{orphans}"
+    abort 'seeding left unparented zones' if orphans.positive?
+  end
+end

--- a/lib/tasks/plant_koppen_zones.rake
+++ b/lib/tasks/plant_koppen_zones.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_koppen_zone_importer')
+
+# Thin wrapper; the reasoning and both guards live in
+# lib/ec_koppen_zone_importer.rb.
+#
+#   bin/rails plants:import_koppen_zones[tmp/zones.json]              # dry run
+#   APPLY=true bin/rails plants:import_koppen_zones[tmp/zones.json]   # write
+#
+# Payload shape: {"plants": {"<uuid>": ["Cfa", "Aw"]}}
+namespace :plants do
+  desc 'Import plant climate-zone assignments from ECHOcommunity (dry run unless APPLY=true)'
+  task :import_koppen_zones, [:path] => :environment do |_t, args|
+    path = args[:path] or
+      abort 'usage: bin/rails plants:import_koppen_zones[path/to/zones.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    payload = JSON.parse(File.read(path))
+    plants = payload['plants'] or abort "no 'plants' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    puts "#{apply ? 'IMPORTING' : 'DRY RUN'} climate zones for #{plants.size} plants"
+    puts "  source environment: #{payload['source'] || 'unknown'}"
+    puts
+
+    result = EcKoppenZoneImporter.new(apply: apply).import(plants)
+
+    puts "  links #{apply ? 'created' : 'to create'}: #{result.linked}"
+    puts "  links already present: #{result.present}"
+    puts "  plants not in this database: #{result.missing_plants}"
+    puts "  unknown zone codes: #{result.unknown_zones.size}"
+    result.unknown_zones.each { |c| puts "    #{c.inspect}" }
+    puts "  failed: #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'climate zone import finished with failures' if result.failed.positive?
+    abort 'payload names zone codes that are not seeded' if result.unknown_zones.any?
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6185,6 +6185,33 @@ type Plant implements Node {
   infoSheetDescription: String
 
   """
+  The Köppen-Geiger climate zones a plant is suited to. Most assignments sit at
+  the subgroup level (Cf, BS) rather than a full class, which records what is
+  known without asserting a summer-temperature class.
+  """
+  koppenZones(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): KoppenZoneConnectionWithTotalCount
+
+  """
   Describes how long a plant takes to complete their entire life cycle
   """
   lifeCycle: LifeCycleValue

--- a/schema.graphql
+++ b/schema.graphql
@@ -3890,6 +3890,131 @@ type ImageEdge {
 }
 
 """
+A Köppen-Geiger climate zone. The list is fixed; only the translated name and description are editable.
+"""
+type KoppenZone implements Node {
+  """
+  True when this zone appears in Beck et al. 2018, the published map legend: the
+  5 groups and 30 classes. The 8 subgroups are an ECHO intermediate level, and
+  BSn/BWn record frequent fog, which map rasters do not resolve. False is a
+  statement about the map product, not about legitimacy.
+  """
+  authoritative: Boolean!
+
+  """
+  The zones one level down
+  """
+  children: [KoppenZone!]!
+
+  """
+  The classification this row was modelled on
+  """
+  classificationSource: String!
+
+  """
+  The source release this row was loaded from
+  """
+  classificationVersion: String!
+
+  """
+  The Köppen code, for example Cfa. Not translated: codes are defined by the classification and do not change.
+  """
+  code: String!
+
+  """
+  The translated description of a climate zone
+  """
+  description: String
+  id: ID!
+
+  """
+  group (A-E), subgroup (Cf, BS, ...) or class (Cfa, BSh, ...)
+  """
+  level: String!
+
+  """
+  The translated name of a climate zone
+  """
+  name: String
+
+  """
+  The zone one level up: Cfa -> Cf -> C
+  """
+  parent: KoppenZone
+
+  """
+  The date of the source release
+  """
+  snapshotDate: ISO8601Date!
+
+  """
+  Translations of translatable climate zone fields
+  """
+  translations: [KoppenZoneTranslation!]!
+
+  """
+  The internal database ID for a climate zone
+  """
+  uuid: ID!
+}
+
+"""
+The connection type for KoppenZone.
+"""
+type KoppenZoneConnectionWithTotalCount {
+  """
+  A list of edges.
+  """
+  edges: [KoppenZoneEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [KoppenZone]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type KoppenZoneEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: KoppenZone
+}
+
+"""
+Translated fields for a climate zone
+"""
+type KoppenZoneTranslation {
+  """
+  The translated description of a climate zone
+  """
+  description: String
+
+  """
+  The locale for this translation
+  """
+  locale: String!
+
+  """
+  The translated name of a climate zone
+  """
+  name: String
+}
+
+"""
 Notation of Plant Lifecycle Events from planting to end-of-life
 """
 interface LifeCycleEvent {
@@ -6998,6 +7123,51 @@ type Query {
     """
     name: String
   ): ImageAttributeConnectionWithTotalCount!
+
+  """
+  Returns a list of Köppen-Geiger climate zones
+  """
+  koppenZones(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Restrict to zones that do (true) or do not (false) appear in Beck et al. 2018
+    """
+    authoritative: Boolean
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Exact, case-insensitive match on the Köppen code
+    """
+    code: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Request returned fields in a specific language. Overrides ACCEPT-LANGUAGE header.
+    """
+    language: String
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Restrict to group, subgroup or class
+    """
+    level: String
+  ): KoppenZoneConnectionWithTotalCount!
 
   """
   Find a life cycle event by ID

--- a/spec/graphql/resolvers/koppen_zones_spec.rb
+++ b/spec/graphql/resolvers/koppen_zones_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/koppen_zone_seeder')
+
+RSpec.describe 'koppenZones' do
+  let(:user) { build(:user, :superadmin) }
+
+  before { KoppenZoneSeeder.new(apply: true).seed }
+
+  def query(args = '', selection: 'code level authoritative')
+    result = PlantApiSchema.execute(
+      "{ koppenZones#{args} { totalCount edges { node { #{selection} } } } }",
+      context: { current_user: user }
+    )
+    raise result['errors'].inspect if result['errors']
+
+    result['data']['koppenZones']
+  end
+
+  it 'returns every zone' do
+    expect(query['totalCount']).to eq 45
+  end
+
+  it 'filters by level' do
+    data = query('(level: "group")')
+
+    expect(data['totalCount']).to eq 5
+    expect(data['edges'].map { |e| e.dig('node', 'code') }).to contain_exactly(*%w[A B C D E])
+  end
+
+  it 'filters by whether the zone appears in Beck 2018' do
+    expect(query('(authoritative: true)')['totalCount']).to eq 35
+    expect(query('(authoritative: false)')['totalCount']).to eq 10
+  end
+
+  it 'matches a code case-insensitively' do
+    data = query('(code: "cfa")')
+
+    expect(data['totalCount']).to eq 1
+    expect(data['edges'].first.dig('node', 'code')).to eq 'Cfa'
+  end
+
+  it 'exposes the hierarchy in both directions' do
+    data = query('(code: "Cf")', selection: 'code parent { code } children { code }')
+    node = data['edges'].first['node']
+
+    expect(node.dig('parent', 'code')).to eq 'C'
+    expect(node['children'].map { |c| c['code'] }).to contain_exactly('Cfa', 'Cfb', 'Cfc')
+  end
+
+  it 'returns the translated name' do
+    data = query('(code: "Aw")', selection: 'code name')
+
+    expect(data['edges'].first.dig('node', 'name')).to eq 'Tropical Savanna Climate'
+  end
+
+  # The lookup is reference data behind a public read, like the other
+  # taxonomies; a tokenless request must still resolve it.
+  it 'is readable without a user' do
+    result = PlantApiSchema.execute('{ koppenZones { totalCount } }', context: {})
+
+    expect(result['errors']).to be_nil
+    expect(result.dig('data', 'koppenZones', 'totalCount')).to eq 45
+  end
+end

--- a/spec/models/koppen_zone_spec.rb
+++ b/spec/models/koppen_zone_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe KoppenZone do
+  def build_zone(code:, level: 'class', **rest)
+    KoppenZone.new(code: code, level: level,
+                   classification_source: 'test', classification_version: 'v1',
+                   snapshot_date: Date.new(2018, 10, 30), **rest)
+  end
+
+  def create_zone(**args)
+    described_class.importing { build_zone(**args).tap(&:save!) }
+  end
+
+  describe 'the locked list' do
+    it 'refuses to create a zone outside an import' do
+      expect { build_zone(code: 'Zz').save! }
+        .to raise_error(KoppenZone::ImmutableListError, /locked reference list/)
+    end
+
+    it 'refuses to destroy a zone outside an import' do
+      zone = create_zone(code: 'Zz')
+
+      expect { zone.destroy! }.to raise_error(KoppenZone::ImmutableListError)
+      expect(described_class.exists?(zone.id)).to be true
+    end
+
+    it 'allows both inside an import' do
+      zone = create_zone(code: 'Zz')
+      expect(zone).to be_persisted
+
+      described_class.importing { zone.destroy! }
+      expect(described_class.exists?(zone.id)).to be false
+    end
+
+    # The model callback alone is bypassed by insert_all, delete_all and a
+    # console session, which is the whole reason the trigger exists.
+    it 'is enforced by the database, not just the model' do
+      expect {
+        described_class.insert_all([{ code: 'Yy', level: 'class',
+                                      classification_source: 't',
+                                      classification_version: 'v1',
+                                      snapshot_date: Date.new(2018, 10, 30),
+                                      created_at: Time.current,
+                                      updated_at: Time.current }])
+      }
+        .to raise_error(ActiveRecord::StatementInvalid, /locked reference list/)
+    end
+
+    it 'relocks after an import, even when one raised' do
+      expect do
+        described_class.importing { raise 'boom' }
+      end.to raise_error('boom')
+
+      expect { build_zone(code: 'Xx').save! }
+        .to raise_error(KoppenZone::ImmutableListError)
+    end
+  end
+
+  describe 'validation' do
+    it 'rejects a level outside the three' do
+      zone = build_zone(code: 'Qq', level: 'kingdom')
+      expect(zone).not_to be_valid
+      expect(zone.errors[:level]).to be_present
+    end
+
+    it 'requires the provenance columns' do
+      zone = KoppenZone.new(code: 'Qq', level: 'class')
+      expect(zone).not_to be_valid
+      expect(zone.errors.attribute_names)
+        .to include(:classification_source, :classification_version, :snapshot_date)
+    end
+
+    it 'refuses to be its own parent' do
+      zone = create_zone(code: 'Zz')
+      zone.parent_id = zone.id
+      expect(zone).not_to be_valid
+    end
+  end
+
+  describe 'the hierarchy' do
+    it 'walks up to the group, nearest first' do
+      group = create_zone(code: 'C', level: 'group')
+      sub = create_zone(code: 'Cf', level: 'subgroup', parent: group)
+      leaf = create_zone(code: 'Cfa', level: 'class', parent: sub)
+
+      expect(leaf.ancestry.map(&:code)).to eq %w[Cf C]
+      expect(group.ancestry).to be_empty
+    end
+
+    it 'will not let a parent be destroyed out from under its children' do
+      group = create_zone(code: 'C', level: 'group')
+      create_zone(code: 'Cf', level: 'subgroup', parent: group)
+
+      described_class.importing { expect(group.destroy).to be false }
+      expect(described_class.exists?(group.id)).to be true
+    end
+  end
+
+  it 'keeps the translated name in the editable layer' do
+    zone = create_zone(code: 'Cfa')
+    Mobility.with_locale(:en) { zone.update!(name: 'Humid subtropical') }
+
+    expect(Mobility.with_locale(:en) { zone.reload.name }).to eq 'Humid subtropical'
+    expect(zone.translations_array.first[:locale]).to eq 'en'
+  end
+end

--- a/spec/tasks/koppen_zone_seeder_spec.rb
+++ b/spec/tasks/koppen_zone_seeder_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/koppen_zone_seeder')
+
+RSpec.describe KoppenZoneSeeder do
+  def seed(apply: true)
+    described_class.new(apply: apply).seed
+  end
+
+  it 'seeds all 45 zones across the three levels' do
+    result = seed
+
+    expect(result.created).to eq 45
+    expect(KoppenZone.groups.count).to eq 5
+    expect(KoppenZone.subgroups.count).to eq 8
+    expect(KoppenZone.classes.count).to eq 32
+  end
+
+  it 'parents every non-group zone' do
+    seed
+
+    expect(KoppenZone.where(parent_id: nil).where.not(level: 'group')).to be_empty
+    expect(KoppenZone.groups.where.not(parent_id: nil)).to be_empty
+  end
+
+  it 'builds the chain Cfa -> Cf -> C' do
+    seed
+
+    expect(KoppenZone.find_by(code: 'Cfa').ancestry.map(&:code)).to eq %w[Cf C]
+  end
+
+  # A and E have no intermediate level in the classification, so their classes
+  # hang directly off the group.
+  it 'parents the tropical and polar classes straight to their group' do
+    seed
+
+    expect(KoppenZone.find_by(code: 'Aw').parent.code).to eq 'A'
+    expect(KoppenZone.find_by(code: 'ET').parent.code).to eq 'E'
+  end
+
+  # `authoritative` means "appears in Beck et al. 2018": the 5 groups and the
+  # 30 published classes, but not ECHO's 8 intermediates nor the fog variants.
+  it 'flags exactly the 35 rows that appear in Beck 2018' do
+    seed
+
+    expect(KoppenZone.authoritative.count).to eq 35
+    expect(KoppenZone.find_by(code: 'Cf').authoritative).to be false
+    expect(KoppenZone.find_by(code: 'Cfa').authoritative).to be true
+    expect(KoppenZone.find_by(code: 'BSn').authoritative).to be false
+  end
+
+  it 'keeps the two fog variants, parented under their subgroup' do
+    seed
+
+    expect(KoppenZone.find_by(code: 'BSn').parent.code).to eq 'BS'
+    expect(KoppenZone.find_by(code: 'BWn').parent.code).to eq 'BW'
+  end
+
+  it 'corrects the three name errors carried from ECHOcommunity' do
+    seed
+
+    names = KoppenZone.where(code: %w[BSn BWn Dsa]).to_h do |z|
+      [z.code, Mobility.with_locale(:en) { z.name }]
+    end
+    expect(names['BSn']).to eq 'Mild Arid Steppe Climate'      # was "Climante"
+    expect(names['BWn']).to eq 'Mild Arid Desert Climate'      # was "Clomate"
+    expect(names['Dsa']).to eq 'Continental Climate with Hot Dry Summer'
+    expect(names['Dsa']).not_to include '  '                   # had a double space
+  end
+
+  it 'is idempotent' do
+    seed
+    result = seed
+
+    expect(result.created).to eq 0
+    expect(result.updated).to eq 0
+    expect(KoppenZone.count).to eq 45
+  end
+
+  # The name lives in the editable translated layer, so a curator's wording
+  # must survive a re-seed of the structural columns.
+  it 'leaves a curated name alone on re-seed' do
+    seed
+    zone = KoppenZone.find_by(code: 'Cfa')
+    Mobility.with_locale(:en) { zone.update!(name: 'Humid subtropical') }
+
+    seed
+
+    expect(Mobility.with_locale(:en) { zone.reload.name }).to eq 'Humid subtropical'
+  end
+
+  it 'writes nothing on a dry run' do
+    result = seed(apply: false)
+
+    expect(result.created).to eq 45
+    expect(KoppenZone.count).to eq 0
+  end
+end

--- a/spec/tasks/plant_koppen_zones_spec.rb
+++ b/spec/tasks/plant_koppen_zones_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/ec_koppen_zone_importer')
+require Rails.root.join('lib/koppen_zone_seeder')
+
+RSpec.describe EcKoppenZoneImporter do
+  let(:org) { create(:organization, :real) }
+  let(:plant) do
+    create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+  end
+
+  before { KoppenZoneSeeder.new(apply: true).seed }
+
+  def import(plants, apply: true)
+    described_class.new(apply: apply).import(plants)
+  end
+
+  it 'links a plant to the zones it is assigned' do
+    result = import({ plant.id => %w[Cfa Aw] })
+
+    expect(result.linked).to eq 2
+    expect(plant.reload.koppen_zones.map(&:code)).to contain_exactly('Cfa', 'Aw')
+  end
+
+  # ECHOcommunity's zone ids are integers on an un-foreign-keyed table whose
+  # rows have been deleted before; the code is the only shared identifier.
+  it 'matches the zone code case-insensitively' do
+    result = import({ plant.id => ['cfa'] })
+
+    expect(result.linked).to eq 1
+    expect(plant.reload.koppen_zones.first.code).to eq 'Cfa'
+  end
+
+  it 'does not duplicate a link that already exists' do
+    import({ plant.id => ['Cfa'] })
+    result = import({ plant.id => ['Cfa'] })
+
+    expect(result.linked).to eq 0
+    expect(result.present).to eq 1
+    expect(plant.reload.koppen_zones.count).to eq 1
+  end
+
+  # koppen_zones is a locked list. A code that is not in it means the seed and
+  # the payload disagree, which must surface rather than be papered over.
+  it 'reports an unknown zone code and never creates one' do
+    result = import({ plant.id => %w[Cfa Zz] })
+
+    expect(result.unknown_zones).to eq ['Zz']
+    expect(result.linked).to eq 1
+    expect(KoppenZone.count).to eq 45
+  end
+
+  it 'skips a plant that is not in this database' do
+    result = import({ SecureRandom.uuid => ['Cfa'] })
+
+    expect(result.missing_plants).to eq 1
+    expect(result.failed).to eq 0
+  end
+
+  # Removing an assignment is an editorial act, not a migration one.
+  it 'is additive: a zone the payload omits stays linked' do
+    import({ plant.id => %w[Cfa Aw] })
+    import({ plant.id => ['Cfa'] })
+
+    expect(plant.reload.koppen_zones.map(&:code)).to contain_exactly('Cfa', 'Aw')
+  end
+
+  it 'links to a subgroup, which is where most assignments sit' do
+    result = import({ plant.id => ['Cf'] })
+
+    expect(result.linked).to eq 1
+    expect(plant.reload.koppen_zones.first.level).to eq 'subgroup'
+  end
+
+  it 'writes nothing on a dry run' do
+    result = import({ plant.id => ['Cfa'] }, apply: false)
+
+    expect(result.linked).to eq 1
+    expect(plant.reload.koppen_zones).to be_empty
+  end
+end


### PR DESCRIPTION
The prerequisite for migrating the GMCC selector (D-009, D-017). ECHOcommunity
holds **512 plant-to-climate-zone assignments** across 45 zones; the API had
neither the lookup nor anywhere to put the links.

Two stacked commits: the lookup, then the assignments that need it.

## The lookup

45 rows in three self-parented levels — **5 groups, 8 subgroups, 32 classes** —
modelled on the botanical-families pattern: `code` as the natural key, a
**database-level locked list**, `classification_source` / `classification_version`
/ `snapshot_date` provenance, and an ECHO-owned editable translated name on top.

**The 8 subgroups are not in the published classification** — `Cf`, `BS`, `Dw`
and friends sit between group and class. They are kept because they carry
**306 of the 512 assignments**. A plant recorded as `Cf` states what is known
without asserting a summer-temperature class, and deciding whether it means
`Cfa`, `Cfb` or `Cfc` is an agronomic judgement, not a lookup. Adopting only the
30 published classes would make the majority of ECHO's data inexpressible
without re-tagging.

`authoritative` marks the **35 rows that do appear in Beck et al. 2018** (5
groups + 30 classes), so the distinction stays legible rather than being
flattened away. It is a statement about the map product, not about legitimacy.

**`BSn` and `BWn` are kept.** They were first taken for ECHO inventions. `n` is
a recognised third letter meaning *frequent fog* (Lima, Walvis Bay); it is
absent from Beck only because map rasters do not resolve fog.

## The assignments

**Zones are matched by `code`, never by id.** ECHOcommunity's zone ids are
integers on a table with no foreign keys whose rows have been deleted before —
the parent ids are non-contiguous — so the code is the only identifier
meaningful in both systems.

The new join carries the **foreign keys and unique index ECHOcommunity's
lacks**, which is precisely how its table came to hold a row pointing at a zone
that no longer exists. The exporter reports and drops it: **513 rows in, 512
assignments out across 115 plants**, using 20 distinct zones (`Aw` 106, `Cs` 68,
`Cf` 67, `BS` 64, `Af` 64).

Additive, like the common-name sync: a zone the payload omits stays linked,
because removing an assignment is editorial rather than migration work. An
**unknown zone code aborts the run** rather than being created — `koppen_zones`
is a locked list, so a code that is not in it means the seed and the payload
disagree.

## Details

- The locked-list trigger **branches on `TG_OP`** rather than returning
  `COALESCE(NEW, OLD)` — the bug families had to go back and fix in a third
  migration, because `NEW` is unassigned during a `DELETE`.
- Three name errors carried from ECHOcommunity are corrected on the way in:
  *"Climante"*, *"Clomate"*, and a double space in the `Dsa` name.
- The data table lives in `lib/koppen_zone_data.rb`, apart from the seeding
  logic, so it can be read and diffed as data.
- Seeding is idempotent and deliberately does **not** touch the translated
  name — a curator's wording survives a re-seed.
- `koppenZones` is exposed on the Query type (filters: `code`, `level`,
  `authoritative`; `parent`/`children` for the tree) and on `PlantType`.

## Verification

36 new specs, including that the lock is enforced by the **database** and not
just the model (`insert_all` is rejected), that it relocks after a failed
import, that `Cfa -> Cf -> C` resolves, and that an unknown code creates
nothing. Full suite **2,404 examples, 0 failures**; rubocop clean across 768
files; `schema.graphql` regenerated.