### PR TITLE
Fix KEEP_LOCAL dropping every translated attribute

### DIFF
--- a/app/graphql/mutations/resolve_sync_conflict.rb
+++ b/app/graphql/mutations/resolve_sync_conflict.rb
@@ -93,14 +93,23 @@ module Mutations
     end
 
     # KEEP_LOCAL: mark conflict resolved; adopt current local attrs as new snapshot.
+    #
+    # Reads through SourceSynchronizer.local_attrs, NOT record.attributes.slice.
+    # Mobility is configured with `backend :container` and no attribute_methods
+    # plugin, so translated attributes live in the `translations` jsonb and never
+    # appear in #attributes. Slicing there wrote a snapshot missing every
+    # narrative field, so the next sync still saw local as changed and raised the
+    # same conflict again - keeping a local edit to a description could never
+    # quiesce. The digest is recomputed from the same hash for the same reason:
+    # leaving it stale re-opens the conflict by another route.
     def apply_keep_local(conflict)
       record         = conflict.syncable
-      data_source    = conflict.data_source
-      source_attrs   = data_source_source_attributes(data_source, record)
-      local_snapshot = record.attributes.slice(*source_attrs)
+      source_attrs   = data_source_source_attributes(conflict.data_source, record)
+      local_snapshot = SourceSynchronizer.local_attrs(record, source_attrs)
 
       record.update_columns(
         source_snapshot: local_snapshot,
+        source_digest: canonical_digest(local_snapshot),
         sync_state: 'locally_modified'
       )
 

--- a/app/services/source_synchronizer.rb
+++ b/app/services/source_synchronizer.rb
@@ -125,6 +125,19 @@ class SourceSynchronizer
     report
   end
 
+  # Local state for a set of source-managed attributes, read through the public
+  # readers. See the note on the private instance method below for why this must
+  # never become record.attributes.slice.
+  #
+  # Class-level because Mutations::ResolveSyncConflict needs exactly this read
+  # when it adopts local state as the new snapshot, and reimplemented it with
+  # the slice - reintroducing the bug this method exists to prevent.
+  def self.local_attrs(record, attributes)
+    attributes.each_with_object({}) do |attr, acc|
+      acc[attr] = record.public_send(attr) if record.respond_to?(attr)
+    end
+  end
+
   private
 
   def process_row(row, report)
@@ -261,9 +274,7 @@ class SourceSynchronizer
   # locale returns the :en value. Sync writes and reads within the same locale,
   # so the comparison stays symmetric.
   def local_attrs(record)
-    @source_attributes.each_with_object({}) do |attr, acc|
-      acc[attr] = record.public_send(attr) if record.respond_to?(attr)
-    end
+    self.class.local_attrs(record, @source_attributes)
   end
 
   # base = last accepted source snapshot, sliced to source_attributes

--- a/spec/mutations/resolve_sync_conflict_spec.rb
+++ b/spec/mutations/resolve_sync_conflict_spec.rb
@@ -129,6 +129,44 @@ RSpec.describe 'ResolveSyncConflict Mutation', type: :graphql_mutation do
         expect(plant.source_snapshot).to be_present
       end
 
+      # Regression: apply_keep_local adopted local state with
+      # record.attributes.slice, which omits every Mobility-translated attribute
+      # (backend :container, no attribute_methods plugin). The snapshot it wrote
+      # therefore had no `description`, so the next real sync still scored the
+      # record changed and raised the conflict the curator had just resolved.
+      # Keeping a local edit to a narrative field could never quiesce.
+      #
+      # The existing specs here could not catch it: they resolve conflicts on
+      # scientific_name, a real column. This one drives a translated attribute
+      # through the mutation and then runs an actual synchronizer pass.
+      it 'quiesces a translated attribute, not just a column-backed one' do
+        Mobility.with_locale(:en) { plant.update!(description: 'Curator text') }
+        translated_conflict = create(
+          :sync_conflict, syncable: plant, data_source: data_source,
+                          conflict_type: 'content', status: 'open',
+                          base_payload: { 'description' => 'Original upstream' },
+                          local_payload: { 'description' => 'Curator text' },
+                          incoming_payload: { 'description' => 'Divergent upstream' }
+        )
+
+        execute(translated_conflict, 'KEEP_LOCAL', user)
+        plant.reload
+
+        expect(plant.source_snapshot['description']).to eq('Curator text'),
+                                                        'the adopted snapshot must carry the translated value, not omit it'
+        expect(plant.source_digest).to be_present, 'a stale digest reopens the conflict by another route'
+
+        report = SourceSynchronizer.new(
+          data_source: data_source, model: Plant,
+          source_attributes: %w[description], run_id: SecureRandom.hex(4)
+        ).apply([{ source_record_id: plant.source_record_id, deleted: false,
+                   attributes: { 'description' => 'Curator text' },
+                   source_updated_at: 1.hour.ago }])
+
+        expect(report.conflicts_created).to eq(0),
+                                            'a resolved keep_local must not immediately reopen on the next sync'
+      end
+
       it 'follow-up sync with same incoming creates NO new conflict after keep_local' do
         execute(content_conflict, 'KEEP_LOCAL', user)
         plant.reload


### PR DESCRIPTION
`ResolveSyncConflict#apply_keep_local` adopted local state with
`record.attributes.slice` — **the same Mobility trap** that
`SourceSynchronizer#local_attrs` was written to avoid, and which carries a
20-line comment there explaining why.

Mobility runs `backend :container` with no `attribute_methods` plugin, so
translated attributes live inside the `translations` jsonb and never appear in
`#attributes`. The snapshot KEEP_LOCAL wrote therefore **omitted every narrative
field**.

## Why it matters

The next sync compared a real local `description` against a snapshot that had
none, scored the record changed, and raised the conflict the curator had just
resolved. **Keeping a local edit to a description could never quiesce** — it
would reopen on every run, forever. The digest was left stale too, which reopens
the conflict by a second route.

This surfaces now because content reconciliation is about to run through this
machinery (D-041), and its conflicts are overwhelmingly narrative fields — the
exact ones affected.

## The fix

The safe read is promoted to `SourceSynchronizer.local_attrs(record, attributes)`
and both callers use it, so a third caller cannot reintroduce the trap by
reimplementing it. `source_digest` is recomputed from the same hash.

## Why no existing spec caught it

- `source_synchronizer_translated_spec.rb` covers the translated path but never
  calls the mutation.
- `resolve_sync_conflict_spec.rb` covers the mutation but resolves conflicts on
  `scientific_name`, a real column.

The gap was exactly the intersection. The new spec drives a **translated**
attribute through the **mutation**, then runs a real `SourceSynchronizer` pass
and asserts no conflict reopens.

**Verified by reverting:** with the old `record.attributes.slice` restored the
new spec fails (`the adopted snapshot must carry the translated value, not omit
it`); with the fix it passes.

Full suite **2,405 examples, 0 failures**; rubocop clean across 768 files.