### PR TITLE
Add the sync bootstrap and record linker for reconciliation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Metrics/BlockLength:
         - 'db/migrate/*.rb'
         - 'lib/tasks/ownership.rake'
         - 'lib/tasks/plant_import.rake'
+        - 'lib/tasks/sync.rake'
         - 'lib/tasks/plant_categories.rake'
 Metrics/MethodLength:
     Exclude:

--- a/app/graphql/mutations/resolve_sync_conflict.rb
+++ b/app/graphql/mutations/resolve_sync_conflict.rb
@@ -183,10 +183,10 @@ module Mutations
       end
     end
 
+    # Delegated so the mutation and the synchronizer cannot drift on what
+    # "unchanged" means.
     def canonical_digest(hash)
-      return nil if hash.nil?
-
-      Digest::SHA256.hexdigest(JSON.generate(hash.sort.to_h))
+      SourceSynchronizer.canonical_digest(hash)
     end
   end
 end

--- a/app/services/source_synchronizer.rb
+++ b/app/services/source_synchronizer.rb
@@ -138,6 +138,18 @@ class SourceSynchronizer
     end
   end
 
+  # Canonical digest of a hash: SHA256 of JSON with sorted keys. Returns nil
+  # for a nil hash.
+  #
+  # Class-level alongside .local_attrs, and for the same reason: the digest
+  # defines what "unchanged" means, so every caller must compute it the same
+  # way. The resolve mutation and the record linker both need it.
+  def self.canonical_digest(hash)
+    return nil if hash.nil?
+
+    Digest::SHA256.hexdigest(JSON.generate(hash.sort.to_h))
+  end
+
   private
 
   def process_row(row, report)
@@ -392,8 +404,6 @@ class SourceSynchronizer
   # Canonical digest of a hash: SHA256 of JSON with sorted keys.
   # Returns nil for a nil hash.
   def canonical_digest(hash)
-    return nil if hash.nil?
-
-    Digest::SHA256.hexdigest(JSON.generate(hash.sort.to_h))
+    self.class.canonical_digest(hash)
   end
 end

--- a/lib/ec_data_source.rb
+++ b/lib/ec_data_source.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# The ECHOcommunity data source, and the set of attributes it governs.
+#
+# `data_sources` has no column for the managed attribute set, so it has to live
+# in code — and it has to be STABLE. `SourceSynchronizer` slices both the
+# incoming row and the stored snapshot to this list before digesting them, so
+# adding or removing an entry silently changes the meaning of every digest
+# already on disk and makes the next run score unrelated records as changed.
+# Treat this list as a schema.
+#
+# Two consequences for whoever writes the feed:
+#
+#   * every row must supply EVERY key here, using '' for absent text. A missing
+#     key is not "unchanged" — it changes the digest and reads as an edit.
+#   * only translated narrative text is here. Ranges and boolean flags are
+#     deliberately excluded: they are not translated, ECHOcommunity stores
+#     defaults as data (the 0–14 pH problem), and mixing them in would put a
+#     placeholder-versus-NULL argument inside the same digest as real prose.
+#     They get their own pass.
+module EcDataSource
+  NAME = 'ECHOcommunity'
+  SOURCE_SYSTEM_KEY = 'echocommunity'
+
+  # API attribute names, not ECHOcommunity's. The one non-obvious mapping is
+  # D-025: ECHOcommunity's plants.description (the long narrative) is this
+  # application's info_sheet_description, while its resources.description (the
+  # short summary) is this application's description.
+  PLANT_ATTRIBUTES = %w[
+    description
+    info_sheet_description
+    origin
+    uses
+    cultivation
+    harvesting_and_seed_production
+    pests_and_diseases
+    cooking_and_nutrition
+    attribution
+    asia_regional_info
+    seeding_rate
+    antinutrient_note
+    tolerance_note
+    used_for_fodder_note
+    edible_green_leaves_note
+    edible_mature_fruit_note
+    optimal_temperature_note
+  ].freeze
+
+  class << self
+    # Idempotent. The owning organization is ECHO itself: the data source
+    # belongs to the organization whose records it carries.
+    def find_or_create!(organization:)
+      DataSource.find_or_create_by!(source_system_key: SOURCE_SYSTEM_KEY) do |ds|
+        ds.name = NAME
+        ds.organization = organization
+        ds.notes = 'Plant data migrated from echocommunity.org. See the ' \
+                   'migration workspace decision log, D-002 and D-041.'
+      end
+    end
+
+    def existing
+      DataSource.find_by(source_system_key: SOURCE_SYSTEM_KEY)
+    end
+  end
+end

--- a/lib/ec_record_linker.rb
+++ b/lib/ec_record_linker.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Links existing API plants to their ECHOcommunity originals, and seeds the
+# merge base, so that SourceSynchronizer can be run at all.
+#
+# WHY THIS IS MANDATORY. SourceSynchronizer finds a record with
+# `find_by(data_source_id:, source_record_id:)`. Every one of those columns is
+# NULL today, so a first sync run would match nothing and take the create
+# branch for every row — 830 duplicate plants. Nothing else in the codebase
+# does this stamping.
+#
+# WHAT source_record_id IS. ECHOcommunity's Resource UUID *is* this
+# application's plant id: the 2020 export preserved it, which is why the two
+# datasets still join exactly five years later. So the identifier is the record's
+# own id. That is unusual enough to be worth stating rather than leaving the
+# reader to infer it from `source_record_id: plant.id`.
+#
+# THE MERGE BASE is the interesting part. With `source_snapshot` NULL,
+# SourceSynchronizer treats base as unknown and — correctly, by its own
+# reasoning — refuses to choose a side: anything not digest-identical becomes a
+# conflict. Applied to this dataset that is thousands of conflicts, which is not
+# review, it is noise.
+#
+# We have the genuine common ancestor: `db/seeds/Plants.json`, the 2020 export,
+# checksummed in the migration workspace at baseline/SEED-BASELINE.md and
+# verified to contain exactly the 322 ECHO-owned plants. Seeding it as the base
+# makes the merge a real three-way:
+#
+#   local == base, incoming differs   -> apply ECHOcommunity's value (D-002)
+#   local != base, incoming differs   -> genuine conflict, a human decides
+#   local != base, incoming == base   -> keep the local edit
+#
+# So the only conflicts raised are records edited in plant-admin since 2020 that
+# ECHOcommunity has also changed — which is exactly the set that deserves eyes.
+#
+# For plants imported by this migration rather than seeded in 2020, the base is
+# current local state: they came from ECHOcommunity and have not diverged since,
+# so base == local == incoming and the first run scores them synced.
+class EcRecordLinker
+  Result = Struct.new(:linked, :already_linked, :based_on_seed, :based_on_local,
+                      :not_in_source, :failed, :errors, keyword_init: true)
+
+  # @param source_uuids [Set<String>] ids ECHOcommunity actually holds. Only
+  #   these are linked: stamping a plant that has no upstream original would
+  #   invite a later feed to treat its absence as a deletion.
+  # @param baseline [Hash<String, Hash>] uuid => 2020 attribute hash, already
+  #   sliced to the managed attributes.
+  def initialize(data_source:, source_uuids:, baseline:, apply: false)
+    @data_source = data_source
+    @source_uuids = source_uuids
+    @baseline = baseline
+    @apply = apply
+  end
+
+  # The 2020 export, sliced to the managed attributes and flattened to the
+  # per-locale shape SourceSynchronizer compares. Mobility reads one locale at a
+  # time, and the sync runs in :en, so the base is the English values.
+  def self.baseline_from_seed(attributes, path = Rails.root.join('db/seeds/Plants.json'))
+    return {} unless File.exist?(path)
+
+    JSON.parse(File.read(path)).each_with_object({}) do |row, acc|
+      english = (row['translations'] || {})['en'] || {}
+      merged = row.merge(english)
+      acc[row['uuid']] = attributes.index_with { |a| merged[a].to_s }
+    end
+  end
+
+  def link
+    result = Result.new(linked: 0, already_linked: 0, based_on_seed: 0,
+                        based_on_local: 0, not_in_source: 0, failed: 0, errors: [])
+    Plant.unscoped.find_each { |plant| link_one(plant, result) }
+    result
+  end
+
+  private
+
+  def link_one(plant, result)
+    return result.not_in_source += 1 unless @source_uuids.include?(plant.id)
+    return result.already_linked += 1 if plant.data_source_id.present?
+
+    snapshot, origin = base_for(plant)
+    count_link(result, origin)
+    stamp(plant, snapshot) if @apply
+  rescue StandardError => e
+    result.failed += 1
+    result.errors << "#{plant.id}: #{e.class}: #{e.message}"
+  end
+
+  def count_link(result, origin)
+    result.linked += 1
+    origin == :seed ? result.based_on_seed += 1 : result.based_on_local += 1
+  end
+
+  # update_columns, not update!: this is provenance bookkeeping, not an
+  # editorial change. It must not run validations, touch updated_at, or leave a
+  # PaperTrail version implying someone edited the plant.
+  def stamp(plant, snapshot)
+    plant.update_columns(
+      data_source_id: @data_source.id,
+      source_record_id: plant.id,
+      source_snapshot: snapshot,
+      source_digest: SourceSynchronizer.canonical_digest(snapshot)
+    )
+  end
+
+  # The 2020 export where we have it, otherwise current local state.
+  def base_for(plant)
+    seed = @baseline[plant.id]
+    return [seed, :seed] if seed
+
+    [SourceSynchronizer.local_attrs(plant, EcDataSource::PLANT_ATTRIBUTES), :local]
+  end
+end

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/ec_data_source')
+require Rails.root.join('lib/ec_record_linker')
+
+# Bootstrap for running SourceSynchronizer against ECHOcommunity.
+#
+#   bin/rails sync:bootstrap                       # create the DataSource (idempotent)
+#   bin/rails sync:link_plants[tmp/uuids.json]     # dry run
+#   APPLY=true bin/rails sync:link_plants[...]     # write
+#
+# The uuids file is {"uuids": ["<uuid>", ...]} — the plants ECHOcommunity
+# actually holds. Only those are linked; see lib/ec_record_linker.rb.
+namespace :sync do
+  desc 'Create the ECHOcommunity DataSource (idempotent)'
+  task bootstrap: :environment do
+    org_id = ENV['ECHO_ORG_ID'].presence or
+      abort 'ECHO_ORG_ID is required (the organization the data source belongs to)'
+    org = Organization.find_by(id: org_id) or abort "no organization with id #{org_id}"
+
+    ds = EcDataSource.find_or_create!(organization: org)
+    puts "DataSource #{ds.persisted? ? 'ready' : 'FAILED'}: #{ds.name} (#{ds.source_system_key})"
+    puts "  id:           #{ds.id}"
+    puts "  organization: #{org.name}"
+    puts "  principal:    #{ds.service_principal!.email}"
+    puts "  governs #{EcDataSource::PLANT_ATTRIBUTES.size} plant attributes"
+  end
+
+  desc 'Link API plants to their ECHOcommunity originals and seed the merge base'
+  task :link_plants, [:path] => :environment do |_t, args|
+    path = args[:path] or abort 'usage: bin/rails sync:link_plants[path/to/uuids.json]'
+    abort "file not found: #{path}" unless File.exist?(path)
+
+    data_source = EcDataSource.existing or abort 'run sync:bootstrap first'
+    uuids = JSON.parse(File.read(path))['uuids'] or abort "no 'uuids' key in #{path}"
+    apply = ENV['APPLY'] == 'true'
+
+    baseline = EcRecordLinker.baseline_from_seed(EcDataSource::PLANT_ATTRIBUTES)
+
+    puts "#{apply ? 'LINKING' : 'DRY RUN'} against #{uuids.size} ECHOcommunity plants"
+    puts "  data source:      #{data_source.name} (#{data_source.id})"
+    puts "  2020 baseline:    #{baseline.size} plants available as a merge base"
+    puts
+
+    result = EcRecordLinker.new(data_source: data_source, source_uuids: uuids.to_set,
+                                baseline: baseline, apply: apply).link
+
+    puts "  plants #{apply ? 'linked' : 'to link'}: #{result.linked}"
+    puts "    base = the 2020 export:   #{result.based_on_seed}"
+    puts "    base = current local:     #{result.based_on_local}"
+    puts "  already linked, untouched:  #{result.already_linked}"
+    puts "  not in ECHOcommunity:       #{result.not_in_source}"
+    puts "  failed:                     #{result.failed}"
+    result.errors.first(20).each { |e| puts "    #{e}" }
+    abort 'linking finished with failures' if result.failed.positive?
+  end
+end

--- a/spec/tasks/ec_record_linker_spec.rb
+++ b/spec/tasks/ec_record_linker_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/ec_data_source')
+require Rails.root.join('lib/ec_record_linker')
+
+RSpec.describe EcRecordLinker do
+  let(:org) { create(:organization, :real) }
+  let(:data_source) { EcDataSource.find_or_create!(organization: org) }
+  let(:plant) do
+    create(:plant, owner_organization_id: org.id, source_organization_id: org.id)
+  end
+
+  def link(uuids, baseline: {}, apply: true)
+    described_class.new(data_source: data_source, source_uuids: uuids.to_set,
+                        baseline: baseline, apply: apply).link
+  end
+
+  # Without this stamping, SourceSynchronizer matches nothing and takes the
+  # create branch for every row — duplicating the entire table.
+  it 'stamps the data source and the shared uuid as source_record_id' do
+    result = link([plant.id])
+
+    expect(result.linked).to eq 1
+    plant.reload
+    expect(plant.data_source_id).to eq data_source.id
+    expect(plant.source_record_id).to eq plant.id
+  end
+
+  it 'seeds the merge base from the 2020 export when it has the plant' do
+    baseline = { plant.id => { 'uses' => 'Historic 2020 text' } }
+    result = link([plant.id], baseline: baseline)
+
+    expect(result.based_on_seed).to eq 1
+    expect(plant.reload.source_snapshot).to eq('uses' => 'Historic 2020 text')
+  end
+
+  # Plants this migration imported came from ECHOcommunity and have not
+  # diverged, so their base is what they currently hold.
+  it 'falls back to current local state when the export has no entry' do
+    Mobility.with_locale(:en) { plant.update!(uses: 'Imported text') }
+    result = link([plant.id])
+
+    expect(result.based_on_local).to eq 1
+    expect(plant.reload.source_snapshot['uses']).to eq 'Imported text'
+  end
+
+  it 'records a digest matching the snapshot it wrote' do
+    link([plant.id], baseline: { plant.id => { 'uses' => 'x' } })
+
+    plant.reload
+    expect(plant.source_digest)
+      .to eq SourceSynchronizer.canonical_digest(plant.source_snapshot)
+  end
+
+  # Stamping a plant with no upstream original would invite a later feed to
+  # read its absence as an upstream deletion.
+  it 'leaves a plant ECHOcommunity does not have alone' do
+    plant # the linker walks every plant, so it must exist before the run
+    result = link([])
+
+    expect(result.not_in_source).to eq 1
+    expect(result.linked).to eq 0
+    expect(plant.reload.data_source_id).to be_nil
+  end
+
+  it 'is idempotent: a linked plant is not relinked or rebased' do
+    link([plant.id], baseline: { plant.id => { 'uses' => 'first' } })
+    result = link([plant.id], baseline: { plant.id => { 'uses' => 'second' } })
+
+    expect(result.already_linked).to eq 1
+    expect(result.linked).to eq 0
+    expect(plant.reload.source_snapshot).to eq('uses' => 'first')
+  end
+
+  # Provenance bookkeeping, not an editorial change: no validations, no
+  # updated_at bump, no version implying a human edited the plant.
+  it 'does not touch updated_at or create a version' do
+    before_updated = plant.updated_at
+    before_versions = PaperTrail::Version.where(item_id: plant.id).count
+
+    link([plant.id])
+
+    expect(plant.reload.updated_at).to eq before_updated
+    expect(PaperTrail::Version.where(item_id: plant.id).count).to eq before_versions
+  end
+
+  it 'writes nothing on a dry run' do
+    result = link([plant.id], apply: false)
+
+    expect(result.linked).to eq 1
+    expect(plant.reload.data_source_id).to be_nil
+  end
+
+  describe '.baseline_from_seed' do
+    it 'flattens the English translations onto the row' do
+      file = Rails.root.join('tmp/test_baseline.json')
+      File.write(file, JSON.generate([{ 'uuid' => 'u1', 'scientific_name' => 'S',
+                                        'translations' => { 'en' => { 'uses' => 'U' } } }]))
+      base = described_class.baseline_from_seed(%w[uses scientific_name], file)
+
+      expect(base['u1']).to eq('uses' => 'U', 'scientific_name' => 'S')
+    ensure
+      FileUtils.rm_f(file)
+    end
+
+    it 'reads the real 2020 export, which is the documented merge base' do
+      base = described_class.baseline_from_seed(EcDataSource::PLANT_ATTRIBUTES)
+
+      expect(base.size).to eq(322), 'the checksummed baseline holds exactly 322 plants'
+      expect(base.values.first.keys).to match_array EcDataSource::PLANT_ATTRIBUTES
+    end
+  end
+end


### PR DESCRIPTION
The prerequisites for running `SourceSynchronizer` against ECHOcommunity at all
(D-041). No behaviour changes until the tasks are run.

## The linker is mandatory, not convenience

`SourceSynchronizer` finds records with
`find_by(data_source_id:, source_record_id:)`. **Every one of those columns is
NULL today**, so a first run would match nothing and take the create branch for
all 830 plants — duplicating the entire table. Nothing else in the codebase does
this stamping.

`source_record_id` is the plant's **own id**: the 2020 export preserved
ECHOcommunity's Resource UUID, which is why the two datasets still join exactly
five years later.

## The merge base is the substantive choice

With `source_snapshot` NULL the synchronizer treats base as unknown and —
correctly, by its own reasoning — refuses to choose a side: anything not
digest-identical becomes a conflict. On this dataset that is thousands of
conflicts, which is noise, not review.

We have the genuine common ancestor: `db/seeds/Plants.json`, the 2020 export,
checksummed in the migration workspace and verified to hold exactly the 322
ECHO-owned plants. Seeding it makes the merge really three-way:

| local vs base | incoming | outcome |
|---|---|---|
| unchanged | differs | **apply ECHOcommunity's value** (D-002) |
| changed | differs | **genuine conflict** — a human decides |
| changed | == base | keep the local edit |

So the only conflicts raised are records edited in plant-admin since 2020 that
ECHOcommunity has *also* changed — exactly the set that deserves eyes. Plants
imported by this migration get current local state as their base, since they
came from ECHOcommunity and have not diverged.

## `EcDataSource` pins the governed attribute set

`data_sources` has no column for it, and the digest is computed over it — so
adding or removing an entry silently changes the meaning of every digest already
on disk. The file says to treat it as a schema, and that every feed row must
supply every key (`''` for absent text), because a missing key reads as an edit.

Only translated narrative text is included. Ranges and flags are excluded
deliberately: they are not translated, and ECHOcommunity stores defaults as data
(the 0–14 pH problem), so a placeholder-versus-NULL argument does not belong
inside the same digest as prose. They get their own pass.

## Also

`canonical_digest` joins `local_attrs` as a shared class method, so the
synchronizer, the resolve mutation and the linker cannot drift on what
"unchanged" means — the same drift that produced the KEEP_LOCAL bug in #125.

Linking uses `update_columns`: provenance bookkeeping must not bump
`updated_at` or leave a PaperTrail version implying a human edited the plant.
**A spec pins that**, along with idempotency, the dry run, and that a plant
ECHOcommunity does not have is left alone.

10 new specs; full suite **2,415 examples, 0 failures**; rubocop clean across
772 files.